### PR TITLE
Rename Absolute -> Ordered, Relative -> Unordered

### DIFF
--- a/Sources/SpelledPitch/NamedIntervalQuality.swift
+++ b/Sources/SpelledPitch/NamedIntervalQuality.swift
@@ -85,9 +85,9 @@ public enum NamedIntervalQuality: Invertible {
     case augmentedOrDiminished(Extended)
 
     /// Creates a `NamedIntervalQuality` with a "sanitized interval class` and the given `ordinal`.
-    public init (sanitizedIntervalClass: Double, ordinal: RelativeNamedInterval.Ordinal) {
+    public init (sanitizedIntervalClass: Double, ordinal: NamedUnorderedInterval.Ordinal) {
 
-        func diminishedAndAugmentedThresholds(ordinal: RelativeNamedInterval.Ordinal)
+        func diminishedAndAugmentedThresholds(ordinal: NamedUnorderedInterval.Ordinal)
             -> (Double, Double)
         {
             var result: Double {

--- a/Sources/SpelledPitch/NamedOrderedInterval.swift
+++ b/Sources/SpelledPitch/NamedOrderedInterval.swift
@@ -10,7 +10,7 @@ import DataStructures
 
 /// Named intervals between two `SpelledPitch` values that honors order between `SpelledPitch`
 /// values.
-public struct AbsoluteNamedInterval {
+public struct NamedOrderedInterval {
 
     // MARK: - Associated Types
 
@@ -53,7 +53,7 @@ public struct AbsoluteNamedInterval {
         ///     let fifth: Ordinal = .perfect(.fifth)
         ///     fifth.inverse // => .perfect(.fourth)
         ///
-        public var inverse: AbsoluteNamedInterval.Ordinal {
+        public var inverse: NamedOrderedInterval.Ordinal {
             switch self {
             case .perfect(let ordinal):
                 return .perfect(ordinal.inverse)
@@ -66,7 +66,7 @@ public struct AbsoluteNamedInterval {
     // MARK: - Type Properties
 
     /// Unison interval.
-    public static var unison: AbsoluteNamedInterval {
+    public static var unison: NamedOrderedInterval {
         return .init(.perfect, .unison)
     }
 
@@ -177,13 +177,13 @@ public struct AbsoluteNamedInterval {
     }
 }
 
-extension AbsoluteNamedInterval.Ordinal: Equatable, Hashable { }
-extension AbsoluteNamedInterval: Equatable, Hashable { }
+extension NamedOrderedInterval.Ordinal: Equatable, Hashable { }
+extension NamedOrderedInterval: Equatable, Hashable { }
 
-extension AbsoluteNamedInterval: Invertible {
+extension NamedOrderedInterval: Invertible {
 
     /// - Returns: Inversion of `self`.
-    public var inverse: AbsoluteNamedInterval {
+    public var inverse: NamedOrderedInterval {
         return .init(quality.inverse, ordinal.inverse)
     }
 }

--- a/Sources/SpelledPitch/NamedUnorderedInterval.swift
+++ b/Sources/SpelledPitch/NamedUnorderedInterval.swift
@@ -13,7 +13,7 @@ import Pitch
 
 /// Named intervals between two `SpelledPitch` values that does not honor order between
 /// `SpelledPitch` values.
-public struct RelativeNamedInterval {
+public struct NamedUnorderedInterval {
 
     // MARK: - Associated Types
     
@@ -58,7 +58,7 @@ public struct RelativeNamedInterval {
     // MARK: - Type Properties
 
     /// Unison interval.
-    public static var unison: RelativeNamedInterval {
+    public static var unison: NamedUnorderedInterval {
         return .init(.perfect, .unison)
     }
     
@@ -149,8 +149,8 @@ public struct RelativeNamedInterval {
     }
 }
 
-extension RelativeNamedInterval.Ordinal: Equatable, Hashable { }
-extension RelativeNamedInterval: Equatable, Hashable { }
+extension NamedUnorderedInterval.Ordinal: Equatable, Hashable { }
+extension NamedUnorderedInterval: Equatable, Hashable { }
 
 private func ordered (_ a: SpelledPitchClass, _ b: SpelledPitchClass)
     -> (SpelledPitchClass, SpelledPitchClass)

--- a/Sources/SpelledPitch/SpelledDyad.swift
+++ b/Sources/SpelledPitch/SpelledDyad.swift
@@ -21,20 +21,20 @@ public struct SpelledDyad {
     
     /// - returns: Relative named interval, which does not ordering of `SpelledPitch` values
     /// contained herein.
-    public var relativeInterval: RelativeNamedInterval {
+    public var relativeInterval: NamedUnorderedInterval {
         
         // TODO: Make convenience init
         let lowerSPC = SpelledPitchClass(lower.pitch.class, lower.spelling)
         let higherSPC = SpelledPitchClass(higher.pitch.class, higher.spelling)
         
-        return RelativeNamedInterval(lowerSPC, higherSPC)
+        return NamedUnorderedInterval(lowerSPC, higherSPC)
     }
     
     /// - returns: Absolute named interval, which honors ordering of `SpelledPitch` values
     /// contained herein.
     //
     // FIXME: Implement
-    public var absoluteInterval: AbsoluteNamedInterval {
+    public var absoluteInterval: NamedOrderedInterval {
         fatalError()
     }
     

--- a/Tests/SpelledPitchTests/AbsoluteNamedIntervalTests.swift
+++ b/Tests/SpelledPitchTests/AbsoluteNamedIntervalTests.swift
@@ -11,23 +11,23 @@ import SpelledPitch
 
 class AbsoluteNamedIntervalTests: XCTestCase {
 
-    typealias Ordinal = AbsoluteNamedInterval.Ordinal
+    typealias Ordinal = NamedOrderedInterval.Ordinal
 
     func testSecondOrdinalInverseSeventh() {
         XCTAssertEqual(Ordinal.imperfect(.second).inverse, Ordinal.imperfect(.seventh))
     }
 
     func testAPI() {
-        let _: AbsoluteNamedInterval = .unison
-        let _: AbsoluteNamedInterval = .init(.minor, .second)
-        let _: AbsoluteNamedInterval = .init(.perfect, .fifth)
-        let _: AbsoluteNamedInterval = .init(.perfect, .fourth)
-        let _: AbsoluteNamedInterval = .init(.augmented, .fifth)
-        let _: AbsoluteNamedInterval = .init(.diminished, .fifth)
-        let _: AbsoluteNamedInterval = .init(.augmented, .third)
-        let _: AbsoluteNamedInterval = .init(.minor, .seventh)
-        let _: AbsoluteNamedInterval = .init(.triple, .augmented, .seventh)
-        let _: AbsoluteNamedInterval = .init(.double, .diminished, .fifth)
+        let _: NamedOrderedInterval = .unison
+        let _: NamedOrderedInterval = .init(.minor, .second)
+        let _: NamedOrderedInterval = .init(.perfect, .fifth)
+        let _: NamedOrderedInterval = .init(.perfect, .fourth)
+        let _: NamedOrderedInterval = .init(.augmented, .fifth)
+        let _: NamedOrderedInterval = .init(.diminished, .fifth)
+        let _: NamedOrderedInterval = .init(.augmented, .third)
+        let _: NamedOrderedInterval = .init(.minor, .seventh)
+        let _: NamedOrderedInterval = .init(.triple, .augmented, .seventh)
+        let _: NamedOrderedInterval = .init(.double, .diminished, .fifth)
     }
 
     func testAPIShouldNotCompile() {
@@ -36,48 +36,48 @@ class AbsoluteNamedIntervalTests: XCTestCase {
     }
 
     func testInversionPerfectFifthPerfectFourth() {
-        let P5 = AbsoluteNamedInterval(.perfect, .fifth)
-        let P4 = AbsoluteNamedInterval(.perfect, .fourth)
+        let P5 = NamedOrderedInterval(.perfect, .fifth)
+        let P4 = NamedOrderedInterval(.perfect, .fourth)
         XCTAssertEqual(P5.inverse, P4)
         XCTAssertEqual(P4.inverse, P5)
     }
 
     func testInversionMajorSecondMinorSeventh() {
-        let M2 = AbsoluteNamedInterval(.major, .second)
-        let m7 = AbsoluteNamedInterval(.minor, .seventh)
+        let M2 = NamedOrderedInterval(.major, .second)
+        let m7 = NamedOrderedInterval(.minor, .seventh)
         XCTAssertEqual(M2.inverse, m7)
         XCTAssertEqual(m7.inverse, M2)
     }
 
     func testInversionMajorThirdMinorSixth() {
-        let M3 = AbsoluteNamedInterval(.major, .third)
-        let m6 = AbsoluteNamedInterval(.minor, .sixth)
+        let M3 = NamedOrderedInterval(.major, .third)
+        let m6 = NamedOrderedInterval(.minor, .sixth)
         XCTAssertEqual(M3.inverse, m6)
         XCTAssertEqual(m6.inverse, M3)
     }
 
     func testAbsoluteNamedIntervalOrdinalInversion() {
-        let sixth = AbsoluteNamedInterval.Ordinal.imperfect(.sixth)
-        let expected = AbsoluteNamedInterval.Ordinal.imperfect(.third)
+        let sixth = NamedOrderedInterval.Ordinal.imperfect(.sixth)
+        let expected = NamedOrderedInterval.Ordinal.imperfect(.third)
         XCTAssertEqual(sixth.inverse, expected)
     }
 
     func testDoubleAugmentedThirdDoubleDiminishedSixth() {
-        let AA3 = AbsoluteNamedInterval(.double, .augmented, .third)
-        let dd6 = AbsoluteNamedInterval(.double, .diminished, .sixth)
+        let AA3 = NamedOrderedInterval(.double, .augmented, .third)
+        let dd6 = NamedOrderedInterval(.double, .diminished, .sixth)
         XCTAssertEqual(AA3.inverse, dd6)
         XCTAssertEqual(dd6.inverse, AA3)
     }
 
     func testPerfectOrdinalUnisonInverse() {
-        let unison = AbsoluteNamedInterval.Ordinal.perfect(.unison)
-        let expected = AbsoluteNamedInterval.Ordinal.perfect(.unison)
+        let unison = NamedOrderedInterval.Ordinal.perfect(.unison)
+        let expected = NamedOrderedInterval.Ordinal.perfect(.unison)
         XCTAssertEqual(unison.inverse, expected)
     }
 
     func testPerfectOrdinalFourthFifthInverse() {
-        let fourth = AbsoluteNamedInterval.Ordinal.perfect(.fourth)
-        let fifth = AbsoluteNamedInterval.Ordinal.perfect(.fifth)
+        let fourth = NamedOrderedInterval.Ordinal.perfect(.fourth)
+        let fifth = NamedOrderedInterval.Ordinal.perfect(.fifth)
         XCTAssertEqual(fourth.inverse, fifth)
         XCTAssertEqual(fifth.inverse, fourth)
     }

--- a/Tests/SpelledPitchTests/RelativeNamedIntervalTests.swift
+++ b/Tests/SpelledPitchTests/RelativeNamedIntervalTests.swift
@@ -12,37 +12,37 @@ import SpelledPitch
 
 class RelativeNamedIntervalTests: XCTestCase {
 
-    typealias Ordinal = RelativeNamedInterval.Ordinal
+    typealias Ordinal = NamedUnorderedInterval.Ordinal
 
     func testInitUnisonSamePitchClass() {
         let a = SpelledPitchClass(0, Pitch.Spelling(.c))
         let b = SpelledPitchClass(0, Pitch.Spelling(.c))
-        let result = RelativeNamedInterval(a,b)
-        let expected = RelativeNamedInterval(.perfect, .unison)
+        let result = NamedUnorderedInterval(a,b)
+        let expected = NamedUnorderedInterval(.perfect, .unison)
         XCTAssertEqual(result, expected)
     }
 
     func testCASharpAugmentedSixthDiminishedThird() {
         let a = SpelledPitchClass(0, Pitch.Spelling(.c))
         let b = SpelledPitchClass(10, Pitch.Spelling(.a, .sharp))
-        let result = RelativeNamedInterval(a,b)
-        let expected = RelativeNamedInterval(.single, .diminished, .third)
+        let result = NamedUnorderedInterval(a,b)
+        let expected = NamedUnorderedInterval(.single, .diminished, .third)
         XCTAssertEqual(result, expected)
     }
 
     func testDFSharpMajorThird() {
         let a = SpelledPitchClass(2, Pitch.Spelling(.d))
         let b = SpelledPitchClass(6, Pitch.Spelling(.f, .sharp))
-        let result = RelativeNamedInterval(a,b)
-        let expected = RelativeNamedInterval(.major, .third)
+        let result = NamedUnorderedInterval(a,b)
+        let expected = NamedUnorderedInterval(.major, .third)
         XCTAssertEqual(result, expected)
     }
 
     func testBFlatDSharpAugmentedThird() {
         let a = SpelledPitchClass(10, Pitch.Spelling(.b, .flat))
         let b = SpelledPitchClass(3, Pitch.Spelling(.d, .sharp))
-        let result = RelativeNamedInterval(a,b)
-        let expected = RelativeNamedInterval(.single, .augmented, .third)
+        let result = NamedUnorderedInterval(a,b)
+        let expected = NamedUnorderedInterval(.single, .augmented, .third)
         XCTAssertEqual(result, expected)
     }
 }

--- a/Tests/SpelledPitchTests/SpelledDyadTests.swift
+++ b/Tests/SpelledPitchTests/SpelledDyadTests.swift
@@ -21,7 +21,7 @@ class SpelledDyadTests: XCTestCase {
 
     func assertRelativeNamedInterval(
         for dyad: SpelledDyad,
-        equals interval: RelativeNamedInterval?
+        equals interval: NamedUnorderedInterval?
     )
     {
         XCTAssertEqual(dyad.relativeInterval, interval)
@@ -29,7 +29,7 @@ class SpelledDyadTests: XCTestCase {
 
     func assertAbsoluteInterval(
         for dyad: SpelledDyad,
-        equals interval: AbsoluteNamedInterval?
+        equals interval: NamedOrderedInterval?
     )
     {
         XCTAssertEqual(dyad.absoluteInterval, interval)
@@ -52,24 +52,24 @@ class SpelledDyadTests: XCTestCase {
 
     func testRelativeNamedIntervalPerfectUnison() {
         let spelledDyad = SpelledDyad(c,c)
-        assertRelativeNamedInterval(for: spelledDyad, equals: RelativeNamedInterval(.perfect, .unison))
+        assertRelativeNamedInterval(for: spelledDyad, equals: NamedUnorderedInterval(.perfect, .unison))
     }
 
     func testRelativeNamedIntervalMinorSecond() {
-        assertRelativeNamedInterval(for: SpelledDyad(c, dflat), equals: RelativeNamedInterval(.minor, .second))
+        assertRelativeNamedInterval(for: SpelledDyad(c, dflat), equals: NamedUnorderedInterval(.minor, .second))
     }
 
     func testRelativeNamedIntervalAugmentedFourth() {
         assertRelativeNamedInterval(
             for: SpelledDyad(c, fsharp),
-            equals: RelativeNamedInterval(.single, .augmented, .fourth)
+            equals: NamedUnorderedInterval(.single, .augmented, .fourth)
         )
     }
 
     func testRelativeNamedIntervalDiminishedFourth() {
         assertRelativeNamedInterval(
             for: SpelledDyad(fsharp, bflat),
-            equals: RelativeNamedInterval(.single, .diminished, .fourth)
+            equals: NamedUnorderedInterval(.single, .diminished, .fourth)
         )
     }
 


### PR DESCRIPTION
Renames:
- `AbsoluteNamedInterval` -> `NamedOrderedInterval`
- `RelativeNamedInterval` -> `NamedUnorderedInterval`

Closes #3.