### PR TITLE
Implement Edmonds-Karp algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@
 Model of musical notation.
 
 Work on this branch requires High Sierra, Xcode 9.4-beta, and the Swift 4.2 [toolchain](https://swift.org/download/#snapshots).
+
+Try this:
+
+```Bash
+git clone https://github.com/dn-m/NotationModel
+cd NotationModel
+swift package update
+swift test
+```

--- a/README.md
+++ b/README.md
@@ -8,21 +8,31 @@ Work on this branch requires High Sierra, Xcode 9.4-beta, and the Swift 4.2 [too
 
 Try these:
 
+Clone the repo.
+
 ```Bash
 git clone https://github.com/dn-m/NotationModel
 ```
+
+Dive inside.
 
 ```Bash
 cd NotationModel
 ```
 
+Ask [Swift Package Manager](https://swift.org/package-manager/) to update dependencies (all are `dn-m`)
+
 ```Bash
 swift package update
 ```
 
+Compiles code and runs tests
+
 ```Bash
 swift test
 ```
+
+Ask Swift Package Manager to generate a nice Xcode project
 
 ```Bash
 swift package generate-xcodeproj

--- a/README.md
+++ b/README.md
@@ -6,12 +6,24 @@ Model of musical notation.
 
 Work on this branch requires High Sierra, Xcode 9.4-beta, and the Swift 4.2 [toolchain](https://swift.org/download/#snapshots).
 
-Try this:
+Try these:
 
 ```Bash
 git clone https://github.com/dn-m/NotationModel
+```
+
+```Bash
 cd NotationModel
+```
+
+```Bash
 swift package update
+```
+
+```Bash
 swift test
+```
+
+```Bash
 swift package generate-xcodeproj
 ```

--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ git clone https://github.com/dn-m/NotationModel
 cd NotationModel
 swift package update
 swift test
+swift package generate-xcodeproj
 ```

--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 [![Build Status](https://travis-ci.org/dn-m/NotationModel.svg?branch=master)](https://travis-ci.org/dn-m/NotationModel)
 
-Model of musical notation
+Model of musical notation.
+
+Work on this branch requires High Sierra, Xcode 9.4-beta, and the Swift 4.2 [toolchain](https://swift.org/download/#snapshots).

--- a/README.md
+++ b/README.md
@@ -22,20 +22,26 @@ Dive inside.
 cd NotationModel
 ```
 
-Ask [Swift Package Manager](https://swift.org/package-manager/) to update dependencies (all are `dn-m`)
+Ask [Swift Package Manager](https://swift.org/package-manager/) to update dependencies (all are `dn-m`).
 
 ```Bash
 swift package update
 ```
 
-Compiles code and runs tests
+Compiles code and runs tests in terminal.
 
 ```Bash
 swift test
 ```
 
-Ask Swift Package Manager to generate a nice Xcode project
+Ask Swift Package Manager to generate a nice Xcode project.
 
 ```Bash
 swift package generate-xcodeproj
+```
+
+Open it up.
+
+```Bash
+open NotationModel.xcodeproj/
 ```

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 Model of musical notation.
 
+## Development
+
 Work on this branch requires High Sierra, Xcode 9.4-beta, and the Swift 4.2 [toolchain](https://swift.org/download/#snapshots).
 
-Try these:
+### Build instructions
 
 Clone the repo.
 

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -26,10 +26,15 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
         return graph.paths(from: source, to: sink)
     }
 
+    /// - Returns: The edges whose values are equivalent to the maximum flow along the path from
+    /// the `source` to the `sink` within which the edge resides.
     internal var saturatedEdges: Set<Edge> {
         return saturatedEdges(in: graph, comparingAgainst: residualNetwork)
     }
 
+    /// - Returns: The residual network produced after subtracting the maximum flow from each of the
+    /// edges. The saturated edges will be absent from the `residualNetwork`, as their values
+    /// reached zero in the flow-propagation process.
     private var residualNetwork: Graph<Value> {
         var residualNetwork = graph
         while let path = residualNetwork.shortestPath(from: source, to: sink) {

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -40,6 +40,16 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
         return residualNetwork
     }
 
+    /// - Returns: The two partitions on either side of the s-t cut.
+    internal var partitions: (source: Graph<Value>, sink: Graph<Value>) {
+        let residualNetwork = self.residualNetwork
+        let sourceNodes = residualNetwork.breadthFirstSearch(from: source)
+        let sinkNodes = residualNetwork.reversed.breadthFirstSearch(from: sink)
+        let sourcePartition = Graph(graph.edges(sourceNodes))
+        let sinkPartition = Graph(graph.edges(sinkNodes.reversed()))
+        return (sourcePartition, sinkPartition)
+    }
+
     // TODO: Consider more (space-)efficient storage of Nodes.
     internal var graph: Graph<Value>
     internal var source: Node

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -35,6 +35,8 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
     /// - Returns: The residual network produced after subtracting the maximum flow from each of the
     /// edges. The saturated edges will be absent from the `residualNetwork`, as their values
     /// reached zero in the flow-propagation process.
+    ///
+    /// - TODO: Add backflow to reversed edges.
     private var residualNetwork: Graph<Value> {
         var residualNetwork = graph
         while let path = residualNetwork.shortestPath(from: source, to: sink) {

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -48,6 +48,7 @@ extension Queue: ExpressibleByArrayLiteral {
 
 extension Wetherfield {
 
+    /// - TODO: Make generic
     public struct FlowNetwork {
 
         typealias Path = Graph<UnassignedNodeInfo>.Path

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -42,12 +42,22 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
 
     /// - Returns: The two partitions on either side of the s-t cut.
     internal var partitions: (source: Graph<Value>, sink: Graph<Value>) {
-        let residualNetwork = self.residualNetwork
-        let sourceNodes = residualNetwork.breadthFirstSearch(from: source)
-        let sinkNodes = residualNetwork.reversed.breadthFirstSearch(from: sink)
-        let sourcePartition = Graph(graph.edges(sourceNodes))
-        let sinkPartition = Graph(graph.edges(sinkNodes.reversed()))
-        return (sourcePartition, sinkPartition)
+        return (graph(sourceReachableNodes), graph(sinkReachableNodes.reversed()))
+    }
+
+    /// - Returns: Nodes in residual network reachable forwards from the `source`.
+    private var sourceReachableNodes: [Node] {
+        return residualNetwork.breadthFirstSearch(from: source)
+    }
+
+    /// - Returns: Nodes in residual network reachable backwards from the `sink`.
+    private var sinkReachableNodes: [Node] {
+        return residualNetwork.reversed.breadthFirstSearch(from: sink)
+    }
+
+    /// - Returns: A `Graph` composed of the given `nodes`, and corresponding edges in this graph.
+    private func graph(_ nodes: [Node]) -> Graph<Value> {
+        return Graph(graph.edges(nodes))
     }
 
     // TODO: Consider more (space-)efficient storage of Nodes.

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -145,5 +145,13 @@ extension Wetherfield {
         internal var paths: Set<Path> {
             return graph.paths(from: source, to: sink)
         }
+
+        /// - TODO: Implement
+        private func edmondsKarp() {
+            // Get shortest path:
+            let shortestPath = graph.shortestPath(from: source, to: sink)
+            // Get maximum flow of shortest path:
+            
+        }
     }
 }

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -60,6 +60,7 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
     /// - Returns: The residual network of this one after pushing maximum flow through.
     //
     // TODO: Create / update reverse edges!
+    // TODO: Create two subgraphs (from sink, and to source)
     internal func edmondsKarp() -> FlowNetwork {
         let minimumCut = saturatedEdges(in: graph, comparingAgainst: residualNetwork)
         return FlowNetwork(residualNetwork, source: source, sink: sink)

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -148,10 +148,18 @@ extension Wetherfield {
 
         /// - TODO: Implement
         private func edmondsKarp() {
+
+            // Create Residual Network
+            var residual = graph
+
+            // Iterate over Augmenting Paths
+
             // Get shortest path:
-            let shortestPath = graph.shortestPath(from: source, to: sink)
+            let shortestPath = graph.shortestPath(from: source, to: sink)!
             // Get maximum flow of shortest path:
-            
+            let maximumFlow = shortestPath.map { $0.value }.min()!
+
+            // ...
         }
     }
 }

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -57,6 +57,8 @@ extension Wetherfield {
         internal struct UnassignedNodeInfo: Hashable {
 
             /// The `pitchClass` which is being represented by a given `Node`.
+            ///
+            /// - TODO: Make reference to `box` for `notehead` (pitch event) instead of `Pitch.Class`.
             let pitchClass: Pitch.Class
 
             /// Index of the node in the `Box` for the given `pitchClass`. Will be either `0`, or

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -5,165 +5,54 @@
 //  Created by James Bean on 5/24/18.
 //
 
-import Pitch
+/// Directed Graph with several properties:
+/// - Each edge has a capacity for flow
+/// - A "source" node, which is only emanates flow outward
+/// - A "sink" node, which only receives flow
+public struct FlowNetwork <Value: Hashable>: Hashable {
 
-/// Queue.
-///
-/// - TODO: Move to dn-m/Structure/DataStructures
-public struct Queue <Element: Equatable> {
+    public typealias Path = Graph<Value>.Path
+    public typealias Node = Graph<Value>.Node
 
-    private var storage: [Element] = []
-
-    public var isEmpty: Bool {
-        return storage.isEmpty
+    /// - Returns: All of the `Node` values contained herein which are neither the `source` nor
+    /// the `sink`.
+    public var internalNodes: [Node] {
+        return graph.nodes.filter { $0 != source && $0 != sink }
     }
 
-    public var count: Int {
-        return storage.count
+    /// - Returns: All of the paths from the `source` to the `sink`.
+    internal var paths: Set<Path> {
+        return graph.paths(from: source, to: sink)
     }
 
-    public mutating func push(_ value: Element) {
-        storage.append(value)
+    // TODO: Consider more (space-)efficient storage of Nodes.
+    internal var graph: Graph<Value>
+    internal var source: Node
+    internal var sink: Node
+
+    // MARK: - Initializers
+
+    /// Create a `FlowNetwork` with the given `graph` and the given `source` and `sink` nodes.
+    public init(_ graph: Graph<Value>, source: Graph<Value>.Node, sink: Graph<Value>.Node) {
+        self.graph = graph
+        self.source = source
+        self.sink = sink
     }
 
-    public mutating func pop() -> Element {
-        return storage.remove(at: 0)
+    /// - Returns: The residual network of this one after pushing maximum flow through.
+    internal func edmondsKarp() -> FlowNetwork {
+        var residualNetwork = graph
+        var maximumNetworkFlow: Double = 0
+        while let path = residualNetwork.shortestPath(from: source, to: sink) {
+            let maximumPathFlow = min(maximumFlow(of: path), .greatestFiniteMagnitude)
+            residualNetwork.insertPath(path.map { $0 - maximumPathFlow })
+            // TODO: Create / update reverse edge
+            maximumNetworkFlow += maximumPathFlow
+        }
+        return FlowNetwork(residualNetwork, source: source, sink: sink)
     }
 
-    public func contains(_ value: Element) -> Bool {
-        if storage.index(of: value) != nil {
-            return true
-        }
-        return false
-    }
-}
-
-extension Queue: ExpressibleByArrayLiteral {
-
-    /// Create a `Queue` with an `ArrayLiteral`.
-    public init(arrayLiteral elements: Element...) {
-        self.storage = elements
-    }
-}
-
-extension Wetherfield {
-
-    /// - TODO: Make generic
-    public struct FlowNetwork {
-
-        typealias Path = Graph<UnassignedNodeInfo>.Path
-        typealias Node = Graph<UnassignedNodeInfo>.Node
-
-        internal struct UnassignedNodeInfo: Hashable {
-
-            /// The `pitchClass` which is being represented by a given `Node`.
-            ///
-            /// - TODO: Make reference to `box` for `notehead` (pitch event) instead of `Pitch.Class`.
-            let pitchClass: Pitch.Class
-
-            /// Index of the node in the `Box` for the given `pitchClass`. Will be either `0`, or
-            /// `1`. This value will ultimately represent the index within a `TendencyPair`.
-            let index: Int
-        }
-
-        internal struct AssignedNodeInfo: Hashable {
-
-            /// The `pitchClass` which is being represented by a given `Node`.
-            let pitchClass: Pitch.Class
-
-            /// Index of the node in the `Box` for the given `pitchClass`. Will be either `0`, or
-            /// `1`. This value will ultimately represent the index within a `TendencyPair`.
-            let index: Int
-
-            /// The "tendency" value assigned subsequent to finding the minium cut.
-            let tendency: PitchSpeller.Category.Tendency
-
-            // MARK: - Initializers
-
-            init(_ nodeInfo: UnassignedNodeInfo, tendency: PitchSpeller.Category.Tendency) {
-                self.pitchClass = nodeInfo.pitchClass
-                self.index = nodeInfo.index
-                self.tendency = tendency
-            }
-        }
-
-        // TODO: Consider more (space-)efficient storage of Nodes.
-        internal var graph: Graph<UnassignedNodeInfo>
-        internal var source: Node
-        internal var sink: Node
-        internal var internalNodes: [Node] = []
-
-        // TODO: Expand this out so that each "notehead" (pitch-event) has a `box` of two nodes as
-        // opposed to only a single `Pitch.Class` having a `box`.
-        public init(pitchClasses: Set<Pitch.Class>, parsimonyPivot: Pitch.Class = 2) {
-
-            // Create an empty `Graph`.
-            self.graph = Graph()
-
-            // Create the `source` node of the pair representing the `parsimony pivot`.
-            self.source = self.graph.createNode(
-                UnassignedNodeInfo(pitchClass: parsimonyPivot, index: 0)
-            )
-
-            // Create the `sink` node of the pair representing the `parsimony pivot`.
-            self.sink = self.graph.createNode(
-                UnassignedNodeInfo(pitchClass: parsimonyPivot, index: 1)
-            )
-
-            // Create nodes for each pitch class in the given `pitchClasses`.
-            for pitchClass in pitchClasses {
-
-                // Create two nodes, one which will represent the `up` tendency (index 0), and the
-                // other which will represent the `down` tendency (index 1)
-                for index in [0,1] {
-                    internalNodes.append(
-                        self.graph.createNode(
-                            UnassignedNodeInfo(pitchClass: pitchClass, index: index)
-                        )
-                    )
-                }
-            }
-
-            // Connect nodes
-            for node in internalNodes {
-
-                // Add edges from source to all internal nodes, with an initial value of 1.
-                self.graph.addEdge(from: source, to: node, value: 1)
-
-                // Add edges from all internal nodes to sink, with an initial value of 1.
-                self.graph.addEdge(from: node, to: sink, value: 1)
-
-                // Add edges from all internal nodes to all other internal nodes.
-                // TODO: Ensure `filter` does not making this accidentally expensive.
-                for other in internalNodes.lazy.filter({ $0 != node }) {
-                    self.graph.addEdge(from: node, to: other, value: 1)
-                }
-            }
-        }
-
-        /// - Returns: All of the paths from the `source` to the `sink`.
-        internal var paths: Set<Path> {
-            return graph.paths(from: source, to: sink)
-        }
-
-        /// - TODO: Implement
-        private func edmondsKarp() {
-
-            // Create Residual Network
-            var residual = graph
-
-            // Iterate over Augmenting Paths
-
-            // Get shortest path:
-            let shortestPath = graph.shortestPath(from: source, to: sink)!
-            // Get maximum flow of shortest path:
-            let maximumFlow = shortestPath.map { $0.value }.min()!
-
-            // ...
-
-            // just keep puuuuushin' it through
-
-            // ...
-        }
+    internal func maximumFlow(of path: Path) -> Double {
+        return path.edges.map { $0.value }.min()!
     }
 }

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -21,11 +21,6 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
         return graph.nodes.filter { $0 != source && $0 != sink }
     }
 
-    /// - Returns: All of the paths from the `source` to the `sink`.
-    internal var paths: Set<Path> {
-        return graph.paths(from: source, to: sink)
-    }
-
     /// - Returns: The edges whose values are equivalent to the maximum flow along the path from
     /// the `source` to the `sink` within which the edge resides.
     internal var saturatedEdges: Set<Edge> {

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -12,6 +12,7 @@
 public struct FlowNetwork <Value: Hashable>: Hashable {
 
     public typealias Path = Graph<Value>.Path
+    public typealias Edge = Graph<Value>.Edge
     public typealias Node = Graph<Value>.Node
 
     /// - Returns: All of the `Node` values contained herein which are neither the `source` nor
@@ -23,6 +24,18 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
     /// - Returns: All of the paths from the `source` to the `sink`.
     internal var paths: Set<Path> {
         return graph.paths(from: source, to: sink)
+    }
+
+    internal var saturatedEdges: Set<Edge> {
+        return saturatedEdges(in: graph, comparingAgainst: residualNetwork)
+    }
+
+    private var residualNetwork: Graph<Value> {
+        var residualNetwork = graph
+        while let path = residualNetwork.shortestPath(from: source, to: sink) {
+            residualNetwork.insertPath(path.map { $0 - maximumFlow(of: path) })
+        }
+        return residualNetwork
     }
 
     // TODO: Consider more (space-)efficient storage of Nodes.
@@ -43,15 +56,26 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
     //
     // TODO: Create / update reverse edges!
     internal func edmondsKarp() -> FlowNetwork {
-        var residualNetwork = graph
-        var maximumNetworkFlow: Double = 0
-        while let path = residualNetwork.shortestPath(from: source, to: sink) {
-            let maximumPathFlow = maximumFlow(of: path)
-            residualNetwork.insertPath(path.map { $0 - maximumPathFlow })
-            // TODO: Create / update reverse edge
-            maximumNetworkFlow += maximumPathFlow
-        }
+        let minimumCut = saturatedEdges(in: graph, comparingAgainst: residualNetwork)
         return FlowNetwork(residualNetwork, source: source, sink: sink)
+    }
+
+    /// - Returns: The set of edges which were saturated (and therefore removed from the residual
+    /// network).
+    private func saturatedEdges(
+        in flowNetwork: Graph<Value>,
+        comparingAgainst residualNetwork: Graph<Value>
+    ) -> Set<Edge>
+    {
+        return Set(
+            flowNetwork.edges.filter { originalEdge in
+                !residualNetwork.edges.contains(
+                    where: { residualEdge in
+                        originalEdge.nodesAreEqual(to: residualEdge)
+                    }
+                )
+            }
+        )
     }
 
     internal func maximumFlow(of path: Path) -> Double {

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -8,6 +8,8 @@
 import Pitch
 
 /// Queue.
+///
+/// - TODO: Move to dn-m/Structure/DataStructures
 public struct Queue <Element: Equatable> {
 
     private var storage: [Element] = []

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -64,15 +64,6 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
         self.sink = sink
     }
 
-    /// - Returns: The residual network of this one after pushing maximum flow through.
-    //
-    // TODO: Create / update reverse edges!
-    // TODO: Create two subgraphs (from sink, and to source)
-    internal func edmondsKarp() -> FlowNetwork {
-        let minimumCut = saturatedEdges(in: graph, comparingAgainst: residualNetwork)
-        return FlowNetwork(residualNetwork, source: source, sink: sink)
-    }
-
     /// - Returns: The set of edges which were saturated (and therefore removed from the residual
     /// network).
     private func saturatedEdges(

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -23,7 +23,7 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
 
     /// - Returns: The edges whose values are equivalent to the maximum flow along the path from
     /// the `source` to the `sink` within which the edge resides.
-    internal var saturatedEdges: Set<Edge> {
+    public var saturatedEdges: Set<Edge> {
         return saturatedEdges(in: graph, comparingAgainst: residualNetwork)
     }
 
@@ -32,7 +32,7 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
     /// reached zero in the flow-propagation process.
     ///
     /// - TODO: Add backflow to reversed edges.
-    private var residualNetwork: Graph<Value> {
+    public var residualNetwork: Graph<Value> {
         var residualNetwork = graph
         while let path = residualNetwork.shortestPath(from: source, to: sink) {
             residualNetwork.insertPath(path.map { $0 - maximumFlow(of: path) })
@@ -41,7 +41,7 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
     }
 
     /// - Returns: The two partitions on either side of the s-t cut.
-    internal var partitions: (source: Graph<Value>, sink: Graph<Value>) {
+    public var partitions: (source: Graph<Value>, sink: Graph<Value>) {
         return (graph(sourceReachableNodes), graph(sinkReachableNodes.reversed()))
     }
 

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -160,6 +160,10 @@ extension Wetherfield {
             let maximumFlow = shortestPath.map { $0.value }.min()!
 
             // ...
+
+            // just keep puuuuushin' it through
+
+            // ...
         }
     }
 }

--- a/Sources/PitchSpeller/FlowNetwork.swift
+++ b/Sources/PitchSpeller/FlowNetwork.swift
@@ -40,11 +40,13 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
     }
 
     /// - Returns: The residual network of this one after pushing maximum flow through.
+    //
+    // TODO: Create / update reverse edges!
     internal func edmondsKarp() -> FlowNetwork {
         var residualNetwork = graph
         var maximumNetworkFlow: Double = 0
         while let path = residualNetwork.shortestPath(from: source, to: sink) {
-            let maximumPathFlow = min(maximumFlow(of: path), .greatestFiniteMagnitude)
+            let maximumPathFlow = maximumFlow(of: path)
             residualNetwork.insertPath(path.map { $0 - maximumPathFlow })
             // TODO: Create / update reverse edge
             maximumNetworkFlow += maximumPathFlow
@@ -53,6 +55,7 @@ public struct FlowNetwork <Value: Hashable>: Hashable {
     }
 
     internal func maximumFlow(of path: Path) -> Double {
-        return path.edges.map { $0.value }.min()!
+        let capacity = path.edges.map { $0.value }.min()!
+        return min(capacity, .greatestFiniteMagnitude)
     }
 }

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -11,7 +11,7 @@ import DataStructures
 /// Minimal implementeation of a Directed Graph with Weighted (/ Capacious) Edges.
 public struct Graph <Value: Hashable> {
 
-    // TODO: Consider making own type which wraps `[Node]`
+    // TODO: Consider making own type which wraps `[Edge]`, or perhaps just use `Graph`.
     public typealias Path = [Edge]
 
     /// Node in a `Graph`. Note that this is a value type. It is stored by its `hashValue`, thereby

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -117,6 +117,7 @@ public struct Graph <Value: Hashable>: Hashable {
         return copy
     }
 
+    /// - Returns: A directed graph with each edge reversed.
     var reversed: Graph {
         let edges = self.edges.map { $0.reversed }
         return Graph(edges)

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -144,6 +144,8 @@ public struct Graph <Value: Hashable> {
     /// given `destination`, if it is reachable. Otherwise, `nil`.
     public func shortestPath(from source: Node, to destination: Node) -> Path? {
 
+        /// In the process of breadth-first searching, each node points to its predecessor. Follow
+        /// this line back to the beginning in order to reconstitute the path travelled.
         func backtrace(from history: [Node: Node]) -> Path {
             var result: [Node] = []
             var current: Node = destination

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -51,17 +51,20 @@ public struct Graph <Value: Hashable>: Hashable {
             self.value = value
         }
 
+        /// - Returns: Graph with nodes updated by the given `transform`.
         public func mapNodes <U> (_ transform: (Value) -> U) -> Graph<U>.Edge {
-            return Graph<U>.Edge(
-                from: source.map(transform),
-                to: destination.map(transform),
-                value: value
-            )
+            return .init(from: source.map(transform), to: destination.map(transform), value: value)
         }
 
         /// - Returns: An `Edge` with the value updated with by the given `transform`.
         public func map(_ transform: (Double) -> Double) -> Edge {
             return Edge(from: source, to: destination, value: transform(value))
+        }
+
+        /// - Returns: `true` if the source and destination nodes of this `Edge` are equivalent to
+        /// those of the given `other`. Otherwise, `false`.
+        public func nodesAreEqual(to other: Edge) -> Bool {
+            return source == other.source && destination == other.destination
         }
     }
 
@@ -263,6 +266,16 @@ public struct Graph <Value: Hashable>: Hashable {
         }
 
         // `destination` is not reachable by `source`.
+        return nil
+    }
+
+    /// - Returns: The edge from the given `source` to the given `destination`, if it exists.
+    /// Otherwise, `nil`.
+    internal func edge(from source: Node, to destination: Node) -> Edge? {
+        guard let edges = adjacencyList[source] else { return nil }
+        for edge in edges where edge.destination == destination {
+            return edge
+        }
         return nil
     }
 

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -187,6 +187,11 @@ public struct Graph <Value: Hashable>: Hashable {
         return edges(from: node).map { $0.destination }
     }
 
+    /// - Returns: `true` if ths graph contains the given `node`. Otherwise, `false`.
+    public func contains(_ node: Node) -> Bool {
+        return nodes.contains(node)
+    }
+
     /// - Returns: The path with the minimum number of edges between the given `source` and the
     /// given `destination`, if it is reachable. Otherwise, `nil`.
     public func shortestPath(from source: Node, to destination: Node) -> Path? {

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -127,10 +127,12 @@ public struct Graph <Value: Hashable>: Hashable {
 
     // MARK: - Initializers
 
+    /// Create a `Graph` with the given `adjacencyList`.
     public init(_ adjacencyList: [Node: [Edge]] = [:]) {
         self.adjacencyList = adjacencyList
     }
 
+    /// Create a `Graph` with the given `edges`.
     public init <S> (_ edges: S) where S: Sequence, S.Element == Edge {
         for edge in edges {
             adjacencyList.safelyAppend(edge, toArrayWith: edge.source)

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -5,6 +5,7 @@
 //  Created by James Bean on 5/24/18.
 //
 
+import Restructure
 import StructureWrapping
 import DataStructures
 
@@ -214,7 +215,7 @@ public struct Graph <Value: Hashable>: Hashable {
                 current = history[current]!
             }
             result.append(source)
-            return makePath(from: Array(result.reversed()))
+            return makePath(from: result.reversed())
         }
 
         // Maps each visited node to its predecessor, which is then backtraced to reconstitute
@@ -249,18 +250,17 @@ public struct Graph <Value: Hashable>: Hashable {
         return nil
     }
 
-    private func edges(_ nodes: [Node]) -> [Edge] {
-        return (nodes.startIndex ..< nodes.endIndex - 1).compactMap { index in
-            let source = nodes[index]
-            let destination = nodes[index + 1]
+    /// - Returns: An array of `Edge` values for the given sequence of `Node` values.
+    private func edges <S> (_ nodes: S) -> [Edge] where S: Sequence, S.Element == Node {
+        return nodes.pairs.compactMap { source, destination in
             return edgeValue(from: source, to: destination).map { value in
                 Edge(from: source, to: destination, value: value)
             }
         }
     }
 
-    /// Create a `Path` from a given array of `nodes`.
-    public func makePath(from nodes: [Node]) -> Path {
+    /// - Returns: A `Path` from a given sequence of `nodes`.
+    public func makePath <S> (from nodes: S) -> Path where S: Sequence, S.Element == Node {
         return Path(edges(nodes))
     }
 }

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -54,6 +54,8 @@ public struct Graph <Value: Hashable> {
     // MARK: - Insance Methods
 
     /// Create a `Node` with the given `value`. This node is placed in the `Graph`.
+    ///
+    /// - Note: Consider making `throw` if value already exists in the graph?
     public mutating func createNode(_ value: Value) -> Node {
         let node = Node(value: value)
         if adjacencyList[node] == nil {

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -342,4 +342,3 @@ extension Graph.Path: CollectionWrapping {
         return edges
     }
 }
-

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -132,15 +132,17 @@ public struct Graph <Value: Hashable> {
         }
 
         let nodes = paths(from: source, to: destination, visited: [], currentPath: [source], accum: [])
+
+        // FIXME: Refactor
         let edges = nodes.map(makePath)
         return Set(edges)
     }
 
     /// - Returns: The path with the minimum number of edges between the given `source` and the
     /// given `destination`, if it is reachable. Otherwise, `nil`.
-    public func shortestPath(from source: Node, to destination: Node) -> [Node]? {
+    public func shortestPath(from source: Node, to destination: Node) -> Path? {
 
-        func backtrace(from history: [Node: Node]) -> [Node] {
+        func backtrace(from history: [Node: Node]) -> Path {
             var result: [Node] = []
             var current: Node = destination
             while current != source {
@@ -148,7 +150,7 @@ public struct Graph <Value: Hashable> {
                 current = history[current]!
             }
             result.append(source)
-            return Array(result.reversed())
+            return makePath(from: Array(result.reversed()))
         }
 
         // Maps each visited node to its predecessor, which is then backtraced to reconstitute

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -39,6 +39,11 @@ public struct Graph <Value: Hashable>: Hashable {
 
         // MARK: - Instance Properties
 
+        /// - Returns: An `Edge` whose direction is reversed.
+        public var reversed: Edge {
+            return Edge(from: destination, to: source, value: value)
+        }
+
         public let source: Node
         public let destination: Node
         public var value: Double

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -88,7 +88,7 @@ public struct Graph <Value: Hashable>: Hashable {
             self.edges = edges
         }
 
-        /// - Returns: A `Path` with the values of each `Edge` updated with by the given `transform`.
+        /// - Returns: A `Path` with the values of each `Edge` updated by the given `transform`.
         public func map(_ transform: (Double) -> Double) -> Path {
             return Path(edges.map { $0.map(transform) })
         }

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -120,17 +120,20 @@ public struct Graph <Value: Hashable>: Hashable {
     }
 
     /// Add an edge from the given `source` to the given `destination` nodes, with the given
-    /// `value` (i.e., weight, or capacity).
+    /// `value` (i.e., weight, or capacity). If the `value` of the edge is 0, the edge is removed.
     public mutating func insertEdge(from source: Node, to destination: Node, value: Double) {
         let edge = Edge(from: source, to: destination, value: value)
         insertEdge(edge)
     }
 
     /// Add the given `edge` if it does not currently exist. Otherwise, replaces the edge with the
-    /// equivalent `source` and `destination` nodes.
+    /// equivalent `source` and `destination` nodes. If the `value` of the edge is 0, the edge is
+    /// removed.
     public mutating func insertEdge(_ edge: Edge) {
         removeEdge(from: edge.source, to: edge.destination)
-        adjacencyList.safelyAppend(edge, toArrayWith: edge.source)
+        if edge.value != 0 {
+            adjacencyList.safelyAppend(edge, toArrayWith: edge.source)
+        }
     }
 
     /// Removes the `Edge` which connects the given `source` and `destination` nodes, if present.

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -106,6 +106,12 @@ public struct Graph <Value: Hashable>: Hashable {
         return adjacencyList.map { node, _ in node }
     }
 
+    /// - Returns: All of the disconnected subgraphs. In the case that the graph is connected, this
+    /// graph will be wrapped up in a single-element set.
+    public var subgraphs: Set<Graph> {
+        fatalError()
+    }
+
     private var adjacencyList: [Node: [Edge]] = [:]
 
     // MARK: - Initializers
@@ -165,8 +171,9 @@ public struct Graph <Value: Hashable>: Hashable {
 
     }
 
-    /// - Returns: The value (i.e., weight, or capacity) of the `Edge` directed from the given `source`,
-    /// to the given `destination`, if the two given nodes are connected. Otherwise, `nil`.
+    /// - Returns: The value (i.e., weight, or capacity) of the `Edge` directed from the given
+    /// `source`, to the given `destination`, if the two given nodes are connected. Otherwise,
+    /// `nil`.
     public func edgeValue(from source: Node, to destination: Node) -> Double? {
         guard let edges = adjacencyList[source] else { return nil }
         for edge in edges {

--- a/Sources/PitchSpeller/Graph.swift
+++ b/Sources/PitchSpeller/Graph.swift
@@ -187,53 +187,6 @@ public struct Graph <Value: Hashable>: Hashable {
         return edges(from: node).map { $0.destination }
     }
 
-    /// - Returns: All of the paths from the given `source` to the given `destination`.
-    public func paths(from source: Node, to destination: Node) -> Set<Path> {
-
-        func paths(
-            from source: Node,
-            to destination: Node,
-            visited: Set<Node>,
-            currentPath: [Node],
-            accum: Set<[Node]>
-        ) -> Set<[Node]>
-        {
-            var visited = visited.inserting(source)
-            var currentPath = currentPath
-            var accum = accum
-
-            // We have found a path!
-            if source == destination {
-                return accum.inserting(currentPath)
-            }
-
-            // Continue on from each node connected from this one.
-            for adjacent in nodesAdjacent(to: source) {
-                if !visited.contains(adjacent) {
-                    currentPath.append(adjacent)
-                    accum.formUnion(
-                        paths(
-                            from: adjacent,
-                            to: destination,
-                            visited: visited,
-                            currentPath: currentPath,
-                            accum: accum
-                        )
-                    )
-                    currentPath.removeLast()
-                }
-            }
-            visited.remove(source)
-            return accum
-        }
-
-        let nodes = paths(from: source, to: destination, visited: [], currentPath: [source], accum: [])
-
-        // FIXME: Refactor
-        let edges = nodes.map(makePath)
-        return Set(edges)
-    }
-
     /// - Returns: The path with the minimum number of edges between the given `source` and the
     /// given `destination`, if it is reachable. Otherwise, `nil`.
     public func shortestPath(from source: Node, to destination: Node) -> Path? {

--- a/Sources/PitchSpeller/Queue.swift
+++ b/Sources/PitchSpeller/Queue.swift
@@ -1,0 +1,45 @@
+//
+//  Queue.swift
+//  PitchSpeller
+//
+//  Created by James Bean on 5/29/18.
+//
+
+/// Queue.
+///
+/// - TODO: Move to dn-m/Structure/DataStructures
+public struct Queue <Element: Equatable> {
+
+    private var storage: [Element] = []
+
+    public var isEmpty: Bool {
+        return storage.isEmpty
+    }
+
+    public var count: Int {
+        return storage.count
+    }
+
+    public mutating func push(_ value: Element) {
+        storage.append(value)
+    }
+
+    public mutating func pop() -> Element {
+        return storage.remove(at: 0)
+    }
+
+    public func contains(_ value: Element) -> Bool {
+        if storage.index(of: value) != nil {
+            return true
+        }
+        return false
+    }
+}
+
+extension Queue: ExpressibleByArrayLiteral {
+
+    /// Create a `Queue` with an `ArrayLiteral`.
+    public init(arrayLiteral elements: Element...) {
+        self.storage = elements
+    }
+}

--- a/Sources/PitchSpeller/Wetherfield.swift
+++ b/Sources/PitchSpeller/Wetherfield.swift
@@ -5,5 +5,95 @@
 //  Created by James Bean on 5/23/18.
 //
 
+import Pitch
+
 /// "Namespace" for Wetherfield Pitch Speller.
-public enum Wetherfield { }
+public enum Wetherfield {
+
+    // TODO: Expand this out so that each "notehead" (pitch-event) has a `box` of two nodes as
+    // opposed to only a single `Pitch.Class` having a `box`.
+    internal static func flowNetwork(
+        pitchClasses: Set<Pitch.Class>,
+        parsimonyPivot: Pitch.Class = 2
+    ) -> FlowNetwork<UnassignedNodeInfo>
+    {
+
+        // Create an empty `Graph`.
+        var graph = Graph<UnassignedNodeInfo>()
+
+        // Create the `source` node of the pair representing the `parsimony pivot`.
+        let source = graph.createNode(
+            UnassignedNodeInfo(pitchClass: parsimonyPivot, index: 0)
+        )
+
+        // Create the `sink` node of the pair representing the `parsimony pivot`.
+        let sink = graph.createNode(
+            UnassignedNodeInfo(pitchClass: parsimonyPivot, index: 1)
+        )
+
+        var internalNodes: [Graph<UnassignedNodeInfo>.Node] = []
+
+        // Create nodes for each pitch class in the given `pitchClasses`.
+        for pitchClass in pitchClasses {
+
+            // Create two nodes, one which will represent the `up` tendency (index 0), and the
+            // other which will represent the `down` tendency (index 1)
+            for index in [0,1] {
+                internalNodes.append(
+                    graph.createNode(UnassignedNodeInfo(pitchClass: pitchClass, index: index))
+                )
+            }
+        }
+
+        // Connect nodes
+        for node in internalNodes {
+
+            // Add edges from source to all internal nodes, with an initial value of 1.
+            graph.insertEdge(from: source, to: node, value: 1)
+
+            // Add edges from all internal nodes to sink, with an initial value of 1.
+            graph.insertEdge(from: node, to: sink, value: 1)
+
+            // Add edges from all internal nodes to all other internal nodes.
+            // TODO: Ensure `filter` does not making this accidentally expensive.
+            for other in internalNodes.lazy.filter({ $0 != node }) {
+                graph.insertEdge(from: node, to: other, value: 1)
+            }
+        }
+
+        return FlowNetwork(graph, source: source, sink: sink)
+    }
+
+    internal struct UnassignedNodeInfo: Hashable {
+
+        /// The `pitchClass` which is being represented by a given `Node`.
+        ///
+        /// - TODO: Make reference to `box` for `notehead` (pitch event) instead of `Pitch.Class`.
+        let pitchClass: Pitch.Class
+
+        /// Index of the node in the `Box` for the given `pitchClass`. Will be either `0`, or
+        /// `1`. This value will ultimately represent the index within a `TendencyPair`.
+        let index: Int
+    }
+
+    internal struct AssignedNodeInfo: Hashable {
+
+        /// The `pitchClass` which is being represented by a given `Node`.
+        let pitchClass: Pitch.Class
+
+        /// Index of the node in the `Box` for the given `pitchClass`. Will be either `0`, or
+        /// `1`. This value will ultimately represent the index within a `TendencyPair`.
+        let index: Int
+
+        /// The "tendency" value assigned subsequent to finding the minium cut.
+        let tendency: PitchSpeller.Category.Tendency
+
+        // MARK: - Initializers
+
+        init(_ nodeInfo: UnassignedNodeInfo, tendency: PitchSpeller.Category.Tendency) {
+            self.pitchClass = nodeInfo.pitchClass
+            self.index = nodeInfo.index
+            self.tendency = tendency
+        }
+    }
+}

--- a/Tests/BeamedRhythmTests/RhythmSpellingTests.swift
+++ b/Tests/BeamedRhythmTests/RhythmSpellingTests.swift
@@ -317,50 +317,50 @@ class RhythmSpellingTests: XCTestCase {
         XCTAssertEqual(makeTieStates(contexts), expected)
     }
     
-    // FIXME: Groups not yet equatable
-    func testInitWithRhythmTree() {
-        
-        let metricalDurationTree = 4/>8 * [1,1,1,1]
-        
-        let metricalContexts: [MetricalContext<Int>] = [
-            .instance(.event(1)),
-            .continuation,
-            .continuation,
-            .instance(.absence)
-        ]
-        
-        let rhythmTree = Rhythm(metricalDurationTree, metricalContexts)
-        let spelling = RhythmSpelling(rhythmTree)
-
-        let expectedBeamJunctions: [RhythmSpelling.BeamJunction] = [
-            [1: .start],
-            [1: .maintain],
-            [1: .maintain],
-            [1: .stop]
-        ].map(RhythmSpelling.BeamJunction.init)
-        
-        let expectedTieStates: [RhythmSpelling.TieState] = [
-            .start,
-            .maintain,
-            .stop,
-            .none
-        ]
-        
-        let expectedDots = [0,0,0,0]
-        
-        let items = zip(
-            expectedBeamJunctions,
-            expectedTieStates,
-            expectedDots
-        ).map(RhythmSpelling.Item.init)
-        
-        // Groups not yet equatable
-        let context = Group(duration: 4/>8, contentsSum: 4).context(range: 0...8)
-        let groups = Grouping.leaf(context)
-        let expected = RhythmSpelling(items: items, groups: groups)
-        
-        XCTAssertEqual(spelling, expected)
-    }
+//    // FIXME: Groups not yet equatable
+//    func testInitWithRhythmTree() {
+//        
+//        let metricalDurationTree = 4/>8 * [1,1,1,1]
+//        
+//        let metricalContexts: [MetricalContext<Int>] = [
+//            .instance(.event(1)),
+//            .continuation,
+//            .continuation,
+//            .instance(.absence)
+//        ]
+//        
+//        let rhythmTree = Rhythm(metricalDurationTree, metricalContexts)
+//        let spelling = RhythmSpelling(rhythmTree)
+//
+//        let expectedBeamJunctions: [RhythmSpelling.BeamJunction] = [
+//            [1: .start],
+//            [1: .maintain],
+//            [1: .maintain],
+//            [1: .stop]
+//        ].map(RhythmSpelling.BeamJunction.init)
+//        
+//        let expectedTieStates: [RhythmSpelling.TieState] = [
+//            .start,
+//            .maintain,
+//            .stop,
+//            .none
+//        ]
+//        
+//        let expectedDots = [0,0,0,0]
+//        
+//        let items = zip(
+//            expectedBeamJunctions,
+//            expectedTieStates,
+//            expectedDots
+//        ).map(RhythmSpelling.Item.init)
+//        
+//        // Groups not yet equatable
+//        let context = Group(duration: 4/>8, contentsSum: 4).context(range: 0...8)
+//        let groups = Grouping.leaf(context)
+//        let expected = RhythmSpelling(items: items, groups: groups)
+//        
+//        XCTAssertEqual(spelling, expected)
+//    }
     
     // FIXME: Not fully implemented
     func testInitWithRhythmTreeDottedValues() {

--- a/Tests/BeamedRhythmTests/RhythmSpellingTests.swift
+++ b/Tests/BeamedRhythmTests/RhythmSpellingTests.swift
@@ -319,9 +319,9 @@ class RhythmSpellingTests: XCTestCase {
     
 //    // FIXME: Groups not yet equatable
 //    func testInitWithRhythmTree() {
-//        
+//
 //        let metricalDurationTree = 4/>8 * [1,1,1,1]
-//        
+//
 //        let metricalContexts: [MetricalContext<Int>] = [
 //            .instance(.event(1)),
 //            .continuation,
@@ -338,30 +338,30 @@ class RhythmSpellingTests: XCTestCase {
 //            [1: .maintain],
 //            [1: .stop]
 //        ].map(RhythmSpelling.BeamJunction.init)
-//        
+//
 //        let expectedTieStates: [RhythmSpelling.TieState] = [
 //            .start,
 //            .maintain,
 //            .stop,
 //            .none
 //        ]
-//        
+//
 //        let expectedDots = [0,0,0,0]
-//        
+//
 //        let items = zip(
 //            expectedBeamJunctions,
 //            expectedTieStates,
 //            expectedDots
 //        ).map(RhythmSpelling.Item.init)
-//        
+//
 //        // Groups not yet equatable
 //        let context = Group(duration: 4/>8, contentsSum: 4).context(range: 0...8)
 //        let groups = Grouping.leaf(context)
 //        let expected = RhythmSpelling(items: items, groups: groups)
-//        
+//
 //        XCTAssertEqual(spelling, expected)
 //    }
-    
+
     // FIXME: Not fully implemented
     func testInitWithRhythmTreeDottedValues() {
         

--- a/Tests/PitchSpellerTests/FlowNetworkTests.swift
+++ b/Tests/PitchSpellerTests/FlowNetworkTests.swift
@@ -28,4 +28,18 @@ class FlowNetworkTests: XCTestCase {
         let residualNetwork = flowNetwork.edmondsKarp()
         print(residualNetwork)
     }
+
+    func testMaximumPathFlow() {
+        var graph = Graph<String>()
+        let source = graph.createNode("source")
+        let sink = graph.createNode("sink")
+        let a = graph.createNode("a")
+        let b = graph.createNode("b")
+        graph.insertEdge(from: source, to: a, value: 1)
+        graph.insertEdge(from: a, to: b, value: 2)
+        graph.insertEdge(from: b, to: sink, value: 3)
+        let flowNetwork = FlowNetwork(graph, source: source, sink: sink)
+        let path = graph.shortestPath(from: source, to: sink)!
+        XCTAssertEqual(flowNetwork.maximumFlow(of: path), 1)
+    }
  }

--- a/Tests/PitchSpellerTests/FlowNetworkTests.swift
+++ b/Tests/PitchSpellerTests/FlowNetworkTests.swift
@@ -9,64 +9,23 @@ import XCTest
 @testable import PitchSpeller
 
 class FlowNetworkTests: XCTestCase {
-    
-    func testInitMonadNodeCount() {
-        let flowNetwork = Wetherfield.FlowNetwork(pitchClasses: [0], parsimonyPivot: 2)
-        XCTAssertEqual(flowNetwork.internalNodes.count, 2)
+
+    var simpleFlowNetwork: FlowNetwork<String> {
+        var graph = Graph<String>()
+        let source = graph.createNode("source")
+        let sink = graph.createNode("sink")
+        let a = graph.createNode("a")
+        let b = graph.createNode("b")
+        graph.insertEdge(from: source, to: a, value: 1)
+        graph.insertEdge(from: source, to: b, value: 2)
+        graph.insertEdge(from: a, to: sink, value: 3)
+        graph.insertEdge(from: b, to: sink, value: 4)
+        return FlowNetwork(graph, source: source, sink: sink)
     }
 
-    func testInitDyadNodeCount() {
-        let flowNetwork = Wetherfield.FlowNetwork(pitchClasses: [0,1], parsimonyPivot: 2)
-        XCTAssertEqual(flowNetwork.internalNodes.count, 4)
+    func testEdmondsKarp() {
+        let flowNetwork = simpleFlowNetwork
+        let residualNetwork = flowNetwork.edmondsKarp()
+        print(residualNetwork)
     }
-
-    func testInitTriadEdges() {
-
-        let flowNetwork = Wetherfield.FlowNetwork(pitchClasses: [0,1,6], parsimonyPivot: 2)
-
-        for internalNode in flowNetwork.internalNodes {
-
-            // Sink is not connected to anything
-            XCTAssertNil(flowNetwork.graph.edgeValue(from: flowNetwork.sink, to: internalNode))
-
-            // Nothing is not connected to the source
-            XCTAssertNil(flowNetwork.graph.edgeValue(from: internalNode, to: flowNetwork.source))
-
-            // Source is connected to all internal nodes
-            XCTAssertNotNil(flowNetwork.graph.edgeValue(from: flowNetwork.source, to: internalNode))
-
-            // All internal nodes are connected to sink
-            XCTAssertNotNil(flowNetwork.graph.edgeValue(from: internalNode, to: flowNetwork.sink))
-
-            // All internal nodes are connected to each other
-            for otherNode in flowNetwork.internalNodes.lazy.filter({ $0 != internalNode}) {
-                XCTAssertNotNil(flowNetwork.graph.edgeValue(from: internalNode, to: otherNode))
-                XCTAssertNotNil(flowNetwork.graph.edgeValue(from: otherNode, to: internalNode))
-            }
-        }
-    }
-
-    func testPaths() {
-        let flowNetwork = Wetherfield.FlowNetwork(pitchClasses: [0], parsimonyPivot: 2)
-
-        //     (0,0)
-        //    / || \
-        //   s  ||  t
-        //    \ || /
-        //     (0,1)
-
-        // Edges:
-        // - Source -> 0,0
-        // - Source -> 0,1
-        // - 0,0 -> 0,1
-        // - 0,1 -> 0,0
-        // - 0,0 -> Sink
-        // - 0,1 -> Sink
-
-        // Paths:
-        // - Source -> (0,0) -> t
-        // - Source -> (0,1) -> t
-        // - Source -> (0,0) -> (0,1) -> t
-        // - Source -> (0,1) -> (0,0) -> t
-    }
-}
+ }

--- a/Tests/PitchSpellerTests/FlowNetworkTests.swift
+++ b/Tests/PitchSpellerTests/FlowNetworkTests.swift
@@ -60,7 +60,7 @@ class FlowNetworkTests: XCTestCase {
         let f = graph.createNode("f")
         let g = graph.createNode("g")
 
-        // hook em up
+        // hook 'em up
         graph.insertEdge(from: a, to: b, value: 3)
         graph.insertEdge(from: a, to: d, value: 3)
         graph.insertEdge(from: b, to: c, value: 4)

--- a/Tests/PitchSpellerTests/FlowNetworkTests.swift
+++ b/Tests/PitchSpellerTests/FlowNetworkTests.swift
@@ -43,7 +43,8 @@ class FlowNetworkTests: XCTestCase {
         XCTAssertEqual(flowNetwork.maximumFlow(of: path), 1)
     }
 
-    func testMaximumNetworkFlow() {
+    func testSaturatedEdges() {
+
         // Example taken from: https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm
         var graph = Graph<String>()
 
@@ -78,5 +79,41 @@ class FlowNetworkTests: XCTestCase {
         let cd = graph.edge(from: c, to: d)!
         let eg = graph.edge(from: e, to: g)!
         XCTAssertEqual(flowNetwork.saturatedEdges, [ad, cd, eg])
+    }
+
+    func testPartitions() {
+
+        // Example taken from: https://www.geeksforgeeks.org/minimum-cut-in-a-directed-graph/
+        var graph = Graph<String>()
+
+        // source
+        let a = graph.createNode("a")
+
+        // sink
+        let b = graph.createNode("b")
+
+        // internal nodes
+        let c = graph.createNode("c")
+        let d = graph.createNode("d")
+        let e = graph.createNode("e")
+        let f = graph.createNode("f")
+
+        graph.insertEdge(from: a, to: b, value: 16)
+        graph.insertEdge(from: a, to: c, value: 13)
+        graph.insertEdge(from: b, to: c, value: 10)
+        graph.insertEdge(from: c, to: b, value: 4)
+        graph.insertEdge(from: b, to: d, value: 12)
+        graph.insertEdge(from: d, to: c, value: 9)
+        graph.insertEdge(from: c, to: e, value: 14)
+        graph.insertEdge(from: e, to: d, value: 7)
+        graph.insertEdge(from: d, to: f, value: 20)
+        graph.insertEdge(from: e, to: f, value: 4)
+        let flowNetwork = FlowNetwork(graph, source: a, sink: f)
+
+        // Expected partitions
+        let sourcePartition = Graph(graph.edges([a,b,c,e]))
+        let sinkPartition = Graph(graph.edges([d,f]))
+        XCTAssertEqual(flowNetwork.partitions.source, sourcePartition)
+        XCTAssertEqual(flowNetwork.partitions.sink, sinkPartition)
     }
  }

--- a/Tests/PitchSpellerTests/FlowNetworkTests.swift
+++ b/Tests/PitchSpellerTests/FlowNetworkTests.swift
@@ -23,12 +23,6 @@ class FlowNetworkTests: XCTestCase {
         return FlowNetwork(graph, source: source, sink: sink)
     }
 
-    func testEdmondsKarp() {
-        let flowNetwork = simpleFlowNetwork
-        let residualNetwork = flowNetwork.edmondsKarp()
-        print(residualNetwork)
-    }
-
     func testMaximumPathFlow() {
         var graph = Graph<String>()
         let source = graph.createNode("source")

--- a/Tests/PitchSpellerTests/FlowNetworkTests.swift
+++ b/Tests/PitchSpellerTests/FlowNetworkTests.swift
@@ -42,4 +42,41 @@ class FlowNetworkTests: XCTestCase {
         let path = graph.shortestPath(from: source, to: sink)!
         XCTAssertEqual(flowNetwork.maximumFlow(of: path), 1)
     }
+
+    func testMaximumNetworkFlow() {
+        // Example taken from: https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm
+        var graph = Graph<String>()
+
+        // source
+        let a = graph.createNode("a")
+
+         // sink
+        let b = graph.createNode("b")
+
+        // internal nodes
+        let c = graph.createNode("c")
+        let d = graph.createNode("d")
+        let e = graph.createNode("e")
+        let f = graph.createNode("f")
+        let g = graph.createNode("g")
+
+        // hook em up
+        graph.insertEdge(from: a, to: b, value: 3)
+        graph.insertEdge(from: a, to: d, value: 3)
+        graph.insertEdge(from: b, to: c, value: 4)
+        graph.insertEdge(from: c, to: a, value: 3)
+        graph.insertEdge(from: c, to: e, value: 2)
+        graph.insertEdge(from: e, to: b, value: 1)
+        graph.insertEdge(from: c, to: d, value: 1)
+        graph.insertEdge(from: d, to: f, value: 6)
+        graph.insertEdge(from: d, to: e, value: 2)
+        graph.insertEdge(from: e, to: g, value: 1)
+        graph.insertEdge(from: f, to: g, value: 9)
+        let flowNetwork = FlowNetwork(graph, source: a, sink: g)
+
+        let ad = graph.edge(from: a, to: d)!
+        let cd = graph.edge(from: c, to: d)!
+        let eg = graph.edge(from: e, to: g)!
+        XCTAssertEqual(flowNetwork.saturatedEdges, [ad, cd, eg])
+    }
  }

--- a/Tests/PitchSpellerTests/GraphTests.swift
+++ b/Tests/PitchSpellerTests/GraphTests.swift
@@ -76,7 +76,7 @@ class GraphTests: XCTestCase {
     func testShortestPathSingleNode() {
         var graph = Graph<String>()
         let a = graph.createNode("a")
-        XCTAssertEqual(graph.shortestPath(from: a, to: a), [a])
+        XCTAssertEqual(graph.shortestPath(from: a, to: a), [])
     }
 
     func testShortestPathTwoUnconnectedNodes() {
@@ -84,7 +84,7 @@ class GraphTests: XCTestCase {
         let a = graph.createNode("a")
         let b = graph.createNode("b")
         XCTAssertEqual(graph.shortestPath(from: a, to: b), nil)
-        XCTAssertEqual(graph.shortestPath(from: b, to: b), [b])
+        XCTAssertEqual(graph.shortestPath(from: b, to: b), [])
     }
 
     func testShortestPathTwoDirectionallyConnectedNodes() {
@@ -92,8 +92,8 @@ class GraphTests: XCTestCase {
         let a = graph.createNode("a")
         let b = graph.createNode("b")
         graph.addEdge(from: a, to: b, value: 1)
-        XCTAssertEqual(graph.shortestPath(from: a, to: b), [a,b])
-        XCTAssertEqual(graph.shortestPath(from: b, to: b), [b])
+        XCTAssertEqual(graph.shortestPath(from: a, to: b), [Graph.Edge(from: a, to: b, value: 1)])
+        XCTAssertEqual(graph.shortestPath(from: b, to: b), [])
     }
 
     func testShortestPathThreeNodes() {
@@ -104,8 +104,8 @@ class GraphTests: XCTestCase {
         graph.addEdge(from: a, to: b, value: 1)
         graph.addEdge(from: b, to: c, value: 0.66)
         graph.addEdge(from: a, to: c, value: 0.33)
-        XCTAssertEqual(graph.shortestPath(from: a, to: c), [a,c])
-        XCTAssertEqual(graph.shortestPath(from: b, to: c), [b,c])
+        XCTAssertEqual(graph.shortestPath(from: a, to: c), [Graph.Edge(from: a, to: c, value: 0.33)])
+        XCTAssertEqual(graph.shortestPath(from: b, to: c), [Graph.Edge(from: b, to: c, value: 0.66)])
     }
 
     func testPaths() {

--- a/Tests/PitchSpellerTests/GraphTests.swift
+++ b/Tests/PitchSpellerTests/GraphTests.swift
@@ -159,16 +159,4 @@ class GraphTests: XCTestCase {
         XCTAssertEqual(graph.edgeValue(from: a, to: b), 2)
         XCTAssertEqual(graph.edgeValue(from: b, to: c), 1)
     }
-
-    func testGraphInsertEdgeWithValueZeroRemoveEdge() {
-        var graph = Graph<String>()
-        let a = graph.createNode("a")
-        let b = graph.createNode("b")
-        let c = graph.createNode("c")
-        graph.insertEdge(from: a, to: b, value: 1)
-        graph.insertEdge(from: b, to: c, value: 1)
-        graph.insertPath(graph.shortestPath(from: a, to: c)!.map { _ in 0 })
-        XCTAssertNil(graph.edgeValue(from: a, to: b))
-        XCTAssertNil(graph.edgeValue(from: b, to: c))
-    }
 }

--- a/Tests/PitchSpellerTests/GraphTests.swift
+++ b/Tests/PitchSpellerTests/GraphTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-import PitchSpeller
+@testable import PitchSpeller
 
 class GraphTests: XCTestCase {
 
@@ -79,9 +79,9 @@ class GraphTests: XCTestCase {
         let c = graph.createNode("c")
         graph.insertEdge(from: a, to: b, value: 1)
         graph.insertEdge(from: a, to: c, value: 0.5)
-        XCTAssertEqual(graph.nodesAdjacent(to: a), [b,c])
-        XCTAssertEqual(graph.nodesAdjacent(to: b), [])
-        XCTAssertEqual(graph.nodesAdjacent(to: c), [])
+        XCTAssertEqual(graph.neighbors(of: a), [b,c])
+        XCTAssertEqual(graph.neighbors(of: b), [])
+        XCTAssertEqual(graph.neighbors(of: c), [])
     }
 
     func testShortestPathSingleNode() {
@@ -152,5 +152,15 @@ class GraphTests: XCTestCase {
         graph.insertPath(graph.shortestPath(from: a, to: c)!.map { _ in 0 })
         XCTAssertNil(graph.edgeValue(from: a, to: b))
         XCTAssertNil(graph.edgeValue(from: b, to: c))
+    }
+
+    func testBreadthFirstSearch() {
+        var graph = Graph<String>()
+        let a = graph.createNode("a")
+        let b = graph.createNode("b")
+        let c = graph.createNode("c")
+        graph.insertEdge(from: a, to: b, value: 1)
+        graph.insertEdge(from: b, to: c, value: 1)
+        XCTAssertEqual(graph.breadthFirstSearch(from: a), [a,b,c])
     }
 }

--- a/Tests/PitchSpellerTests/GraphTests.swift
+++ b/Tests/PitchSpellerTests/GraphTests.swift
@@ -119,24 +119,6 @@ class GraphTests: XCTestCase {
         XCTAssertEqual(graph.shortestPath(from: b, to: c), [Graph.Edge(from: b, to: c, value: 0.66)])
     }
 
-    func testPaths() {
-        var graph = Graph<String>()
-        let a = graph.createNode("a")
-        let b = graph.createNode("b")
-        let c = graph.createNode("c")
-        graph.insertEdge(from: a, to: b, value: 1)
-        graph.insertEdge(from: b, to: c, value: 0.2)
-        graph.insertEdge(from: a, to: c, value: 0.8)
-
-        XCTAssertEqual(
-            graph.paths(from: a, to: c),
-            [
-                [Graph.Edge(from: a, to: b, value: 1), Graph.Edge(from: b, to: c, value: 0.2)],
-                [Graph.Edge(from: a, to: c, value: 0.8)]
-            ]
-        )
-    }
-
     func testInsertEdgeReplacesEdges() {
         var graph = Graph<String>()
         let a = graph.createNode("a")

--- a/Tests/PitchSpellerTests/GraphTests.swift
+++ b/Tests/PitchSpellerTests/GraphTests.swift
@@ -159,4 +159,16 @@ class GraphTests: XCTestCase {
         XCTAssertEqual(graph.edgeValue(from: a, to: b), 2)
         XCTAssertEqual(graph.edgeValue(from: b, to: c), 1)
     }
+
+    func testGraphInsertEdgeWithValueZeroRemoveEdge() {
+        var graph = Graph<String>()
+        let a = graph.createNode("a")
+        let b = graph.createNode("b")
+        let c = graph.createNode("c")
+        graph.insertEdge(from: a, to: b, value: 1)
+        graph.insertEdge(from: b, to: c, value: 1)
+        graph.insertPath(graph.shortestPath(from: a, to: c)!.map { _ in 0 })
+        XCTAssertNil(graph.edgeValue(from: a, to: b))
+        XCTAssertNil(graph.edgeValue(from: b, to: c))
+    }
 }

--- a/Tests/PitchSpellerTests/GraphTests.swift
+++ b/Tests/PitchSpellerTests/GraphTests.swift
@@ -19,7 +19,7 @@ class GraphTests: XCTestCase {
         for indexPair in [(0,2), (1,4), (1,5), (4,7), (4,9)] {
             let (sourceIndex, destinationIndex) = indexPair
             let (source, destination) = (nodes[sourceIndex], nodes[destinationIndex])
-            graph.addEdge(from: source, to: destination, value: Double.random(in: 0...1))
+            graph.insertEdge(from: source, to: destination, value: Double.random(in: 0...1))
         }
         return graph
     }
@@ -43,8 +43,19 @@ class GraphTests: XCTestCase {
         var graph = Graph<Int>()
         let source = graph.createNode(0)
         let destination = graph.createNode(1)
-        graph.addEdge(from: source, to: destination, value: 0.5)
+        graph.insertEdge(from: source, to: destination, value: 0.5)
         XCTAssertEqual(graph.edgeValue(from: source, to: destination), 0.5)
+    }
+
+    func testRemoveEdge() {
+        var graph = Graph<String>()
+        let a = graph.createNode("a")
+        let b = graph.createNode("b")
+        let c = graph.createNode("c")
+        graph.insertEdge(from: a, to: b, value: 1)
+        graph.insertEdge(from: b, to: c, value: 1)
+        graph.removeEdge(from: a, to: b)
+        XCTAssertNil(graph.edgeValue(from: a, to: b))
     }
 
     func testEdgesFromNode() {
@@ -52,8 +63,8 @@ class GraphTests: XCTestCase {
         let a = graph.createNode("a")
         let b = graph.createNode("b")
         let c = graph.createNode("c")
-        graph.addEdge(from: a, to: b, value: 1)
-        graph.addEdge(from: a, to: c, value: 0.5)
+        graph.insertEdge(from: a, to: b, value: 1)
+        graph.insertEdge(from: a, to: c, value: 0.5)
         let edges = graph.edges(from: a)
         let ab = edges[0]
         let ac = edges[1]
@@ -66,8 +77,8 @@ class GraphTests: XCTestCase {
         let a = graph.createNode("a")
         let b = graph.createNode("b")
         let c = graph.createNode("c")
-        graph.addEdge(from: a, to: b, value: 1)
-        graph.addEdge(from: a, to: c, value: 0.5)
+        graph.insertEdge(from: a, to: b, value: 1)
+        graph.insertEdge(from: a, to: c, value: 0.5)
         XCTAssertEqual(graph.nodesAdjacent(to: a), [b,c])
         XCTAssertEqual(graph.nodesAdjacent(to: b), [])
         XCTAssertEqual(graph.nodesAdjacent(to: c), [])
@@ -91,7 +102,7 @@ class GraphTests: XCTestCase {
         var graph = Graph<String>()
         let a = graph.createNode("a")
         let b = graph.createNode("b")
-        graph.addEdge(from: a, to: b, value: 1)
+        graph.insertEdge(from: a, to: b, value: 1)
         XCTAssertEqual(graph.shortestPath(from: a, to: b), [Graph.Edge(from: a, to: b, value: 1)])
         XCTAssertEqual(graph.shortestPath(from: b, to: b), [])
     }
@@ -101,9 +112,9 @@ class GraphTests: XCTestCase {
         let a = graph.createNode("a")
         let b = graph.createNode("b")
         let c = graph.createNode("c")
-        graph.addEdge(from: a, to: b, value: 1)
-        graph.addEdge(from: b, to: c, value: 0.66)
-        graph.addEdge(from: a, to: c, value: 0.33)
+        graph.insertEdge(from: a, to: b, value: 1)
+        graph.insertEdge(from: b, to: c, value: 0.66)
+        graph.insertEdge(from: a, to: c, value: 0.33)
         XCTAssertEqual(graph.shortestPath(from: a, to: c), [Graph.Edge(from: a, to: c, value: 0.33)])
         XCTAssertEqual(graph.shortestPath(from: b, to: c), [Graph.Edge(from: b, to: c, value: 0.66)])
     }
@@ -113,9 +124,9 @@ class GraphTests: XCTestCase {
         let a = graph.createNode("a")
         let b = graph.createNode("b")
         let c = graph.createNode("c")
-        graph.addEdge(from: a, to: b, value: 1)
-        graph.addEdge(from: b, to: c, value: 0.2)
-        graph.addEdge(from: a, to: c, value: 0.8)
+        graph.insertEdge(from: a, to: b, value: 1)
+        graph.insertEdge(from: b, to: c, value: 0.2)
+        graph.insertEdge(from: a, to: c, value: 0.8)
 
         XCTAssertEqual(
             graph.paths(from: a, to: c),
@@ -124,5 +135,40 @@ class GraphTests: XCTestCase {
                 [Graph.Edge(from: a, to: c, value: 0.8)]
             ]
         )
+    }
+
+    func testInsertEdgeReplacesEdges() {
+        var graph = Graph<String>()
+        let a = graph.createNode("a")
+        let b = graph.createNode("b")
+        graph.insertEdge(from: a, to: b, value: 1)
+        graph.insertEdge(from: a, to: b, value: 0.5)
+        XCTAssertEqual(graph.edges.count, 1)
+        XCTAssertEqual(graph.edgeValue(from: a, to: b), 0.5)
+    }
+
+    func testInsertPath() {
+        var graph = Graph<String>()
+        let a = graph.createNode("a")
+        let b = graph.createNode("b")
+        let c = graph.createNode("c")
+        graph.insertEdge(from: a, to: b, value: 1)
+        graph.insertEdge(from: b, to: c, value: 0.5)
+        let path = graph.shortestPath(from: a, to: c)!.map { $0 * 2 }
+        graph.insertPath(path)
+        XCTAssertEqual(graph.edgeValue(from: a, to: b), 2)
+        XCTAssertEqual(graph.edgeValue(from: b, to: c), 1)
+    }
+
+    func testGraphInsertEdgeWithValueZeroRemoveEdge() {
+        var graph = Graph<String>()
+        let a = graph.createNode("a")
+        let b = graph.createNode("b")
+        let c = graph.createNode("c")
+        graph.insertEdge(from: a, to: b, value: 1)
+        graph.insertEdge(from: b, to: c, value: 1)
+        graph.insertPath(graph.shortestPath(from: a, to: c)!.map { _ in 0 })
+        XCTAssertNil(graph.edgeValue(from: a, to: b))
+        XCTAssertNil(graph.edgeValue(from: b, to: c))
     }
 }

--- a/Tests/PitchSpellerTests/WetherfieldTests.swift
+++ b/Tests/PitchSpellerTests/WetherfieldTests.swift
@@ -1,0 +1,72 @@
+//
+//  WetherfieldTests.swift
+//  PitchSpellerTests
+//
+//  Created by James Bean on 5/29/18.
+//
+
+import XCTest
+@testable import PitchSpeller
+
+class WetherfieldTests: XCTestCase {
+    
+    func testInitMonadNodeCount() {
+        let flowNetwork = Wetherfield.flowNetwork(pitchClasses: [0], parsimonyPivot: 2)
+        XCTAssertEqual(flowNetwork.internalNodes.count, 2)
+    }
+
+    func testInitDyadNodeCount() {
+        let flowNetwork = Wetherfield.flowNetwork(pitchClasses: [0,1], parsimonyPivot: 2)
+        XCTAssertEqual(flowNetwork.internalNodes.count, 4)
+    }
+
+    func testInitTriadEdges() {
+
+        let flowNetwork = Wetherfield.flowNetwork(pitchClasses: [0,1,6], parsimonyPivot: 2)
+
+        for internalNode in flowNetwork.internalNodes {
+
+            // Sink is not connected to anything
+            XCTAssertNil(flowNetwork.graph.edgeValue(from: flowNetwork.sink, to: internalNode))
+
+            // Nothing is not connected to the source
+            XCTAssertNil(flowNetwork.graph.edgeValue(from: internalNode, to: flowNetwork.source))
+
+            // Source is connected to all internal nodes
+            XCTAssertNotNil(flowNetwork.graph.edgeValue(from: flowNetwork.source, to: internalNode))
+
+            // All internal nodes are connected to sink
+            XCTAssertNotNil(flowNetwork.graph.edgeValue(from: internalNode, to: flowNetwork.sink))
+
+            // All internal nodes are connected to each other
+            for otherNode in flowNetwork.internalNodes.lazy.filter({ $0 != internalNode}) {
+                XCTAssertNotNil(flowNetwork.graph.edgeValue(from: internalNode, to: otherNode))
+                XCTAssertNotNil(flowNetwork.graph.edgeValue(from: otherNode, to: internalNode))
+            }
+        }
+    }
+
+    func testPaths() {
+        let flowNetwork = Wetherfield.flowNetwork(pitchClasses: [0], parsimonyPivot: 2)
+
+        //     (0,0)
+        //    / || \
+        //   s  ||  t
+        //    \ || /
+        //     (0,1)
+
+        // Edges:
+        // - Source -> 0,0
+        // - Source -> 0,1
+        // - 0,0 -> 0,1
+        // - 0,1 -> 0,0
+        // - 0,0 -> Sink
+        // - 0,1 -> Sink
+
+        // Paths:
+        // - Source -> (0,0) -> t
+        // - Source -> (0,1) -> t
+        // - Source -> (0,0) -> (0,1) -> t
+        // - Source -> (0,1) -> (0,0) -> t
+    }
+}


### PR DESCRIPTION
The [Edmonds-Karp algorithm](https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm) finds the maximum flow (and therefore minimum cut) of a [FlowNetwork](https://en.wikipedia.org/wiki/Flow_network).

We can use this minimum cut to partition a pitch spelling graph into two subgraphs. The source-side- and sink-side-ness can then be assigned to the nodes of the graph. Ultimately, we should be able to decode this info into sharps and flats and so on.