### PR TITLE
Add Tendency conversion tests

### DIFF
--- a/Sources/PitchSpeller/Wetherfield/Tendency.swift
+++ b/Sources/PitchSpeller/Wetherfield/Tendency.swift
@@ -35,9 +35,9 @@ struct TendencyPair: Hashable {
 
 extension Pitch.Spelling {
 
-    /// Creates a `Pitch.Spelling` values with the given `pitchClass` and the given `tendencies`,
+    /// Creates a `Pitch.Spelling` value with the given `pitchClass` and the given `tendencies`,
     /// which are resultant from the Wetherfield-encoded and -decoded `FlowNetwork`, if it is
-    /// possible. Otherwise, fails as `nil`.
+    /// possible. Otherwise, returns `nil`.
     init?(pitchClass: Pitch.Class, tendencies: TendencyPair) {
         guard
             let category = Pitch.Spelling.Category.category(for: pitchClass),

--- a/Tests/PitchSpellerTests/Pitch.Speller+TendencyTests.swift
+++ b/Tests/PitchSpellerTests/Pitch.Speller+TendencyTests.swift
@@ -1,0 +1,36 @@
+//
+//  Pitch.Speller+TendencyTests.swift
+//  PitchSpellerTests
+//
+//  Created by James Bean on 6/10/18.
+//
+
+import XCTest
+import Pitch
+import SpelledPitch
+@testable import PitchSpeller
+
+class PitchSpellingTendencyTests: XCTestCase {
+
+    // MARK: - Category "Zero"
+
+    func testPCZeroUpDown_CNatural() {
+        let expected = Pitch.Spelling(.c)
+        XCTAssertEqual(Pitch.Spelling.init(pitchClass: 0, tendencies: .init(.up,.down)), expected)
+    }
+
+    // MARK: - Category "One"
+
+    // MARK: - Category "Two"
+
+    // MARK: - Category "Three"
+
+    // MARK: - Category "Four"
+
+    // MARK: - Category "Five"
+
+    func testPCEightUpDown_GSharp() {
+        let expected = Pitch.Spelling(.g, .sharp)
+        XCTAssertEqual(Pitch.Spelling.init(pitchClass: 8, tendencies: .init(.up,.down)), expected)
+    }
+}

--- a/Tests/PitchSpellerTests/Pitch.Speller+TendencyTests.swift
+++ b/Tests/PitchSpellerTests/Pitch.Speller+TendencyTests.swift
@@ -21,11 +21,31 @@ class PitchSpellingTendencyTests: XCTestCase {
 
     // MARK: - Category "One"
 
+    func testPCSixUpUp_EDoubleSharp() {
+        let expected = Pitch.Spelling(.e, .doubleSharp)
+        XCTAssertEqual(Pitch.Spelling.init(pitchClass: 6, tendencies: .init(.up,.up)), expected)
+    }
+
     // MARK: - Category "Two"
+
+    func testPCNineDownDown_BDoubleFlat() {
+        let expected = Pitch.Spelling(.b, .doubleFlat)
+        XCTAssertEqual(Pitch.Spelling.init(pitchClass: 9, tendencies: .init(.down,.down)), expected)
+    }
 
     // MARK: - Category "Three"
 
+    func testPCThreeUpDown_EFlat() {
+        let expected = Pitch.Spelling(.e, .flat)
+        XCTAssertEqual(Pitch.Spelling.init(pitchClass: 3, tendencies: .init(.up,.down)), expected)
+    }
+
     // MARK: - Category "Four"
+
+    func testPCElevenUpDown_BNatural() {
+        let expected = Pitch.Spelling(.b, .natural)
+        XCTAssertEqual(Pitch.Spelling.init(pitchClass: 11, tendencies: .init(.up,.down)), expected)
+    }
 
     // MARK: - Category "Five"
 


### PR DESCRIPTION
This PR adds tests confirming that the `Pitch.Spelling` initializer converts Wetherfield-esque `Tendency` values appropriately.