### PR TITLE
Incorporate partial spelled-ness

### DIFF
--- a/Sources/PitchSpeller/Wetherfield/Wetherfield.swift
+++ b/Sources/PitchSpeller/Wetherfield/Wetherfield.swift
@@ -9,16 +9,24 @@ import Restructure
 import Pitch
 import SpelledPitch
 
-struct AssignedNode {
-    let index: Int
-    let tendency: Tendency
-    init(_ index: Int, _ tendency: Tendency) {
-        self.index = index
-        self.tendency = tendency
-    }
+protocol PitchSpellingNode: Hashable {
+    var index: Int { get }
 }
 
 struct PitchSpeller {
+
+    struct UnassignedNode: PitchSpellingNode {
+        let index: Int
+    }
+
+    struct AssignedNode: PitchSpellingNode {
+        let index: Int
+        let assignment: Tendency
+        init(_ index: Int, _ assignment: Tendency) {
+            self.index = index
+            self.assignment = assignment
+        }
+    }
 
     /// - Returns: The nodes for the `Pitch` at the given `index`.
     private static func nodes(pitchAtIndex index: Int) -> (Int, Int) {
@@ -84,7 +92,7 @@ struct PitchSpeller {
 
     private func spellPitch(_ up: AssignedNode, _ down: AssignedNode) -> SpelledPitch {
         let pitch = self.pitch(node: up.index)
-        let tendencies = TendencyPair((up.tendency, down.tendency))
+        let tendencies = TendencyPair((up.assignment, down.assignment))
         let spelling = Pitch.Spelling(pitchClass: pitch.class, tendencies: tendencies)!
         return try! pitch.spelled(with: spelling)
     }

--- a/Sources/PitchSpeller/Wetherfield/Wetherfield.swift
+++ b/Sources/PitchSpeller/Wetherfield/Wetherfield.swift
@@ -42,7 +42,7 @@ struct PitchSpeller {
     // MARK: - Instance Properties
 
     /// The omnipresent, tie-breaking `Pitch.Class` value.
-    let parsimonyPivot: Pitch.Class
+    let parsimonyPivot: Pitch.Spelling
 
     /// The unspelled `Pitch` values to be spelled.
     let pitches: [Pitch]
@@ -57,7 +57,7 @@ struct PitchSpeller {
     // MARK: - Initializers
 
     /// Create a `PitchSpeller` to spell the given `pitches`, with the given `parsimonyPivot`.
-    init(pitches: [Pitch], parsimonyPivot: Pitch.Class = 2) {
+    init(pitches: [Pitch], parsimonyPivot: Pitch.Spelling = .init(.d)) {
         self.pitches = pitches
         self.parsimonyPivot = parsimonyPivot
         self.pitchNodes = PitchSpeller.internalNodes(pitches: pitches)

--- a/Tests/PitchSpellerTests/WetherfieldTests.swift
+++ b/Tests/PitchSpellerTests/WetherfieldTests.swift
@@ -13,18 +13,18 @@ import Pitch
 class WetherfieldTests: XCTestCase {
     
     func testInitMonadNodeCount() {
-        let speller = PitchSpeller(pitches: [60], parsimonyPivot: 2)
+        let speller = PitchSpeller(pitches: [60], parsimonyPivot: Pitch.Spelling(.d))
         XCTAssertEqual(speller.flowNetwork.internalNodes.count, 2)
     }
 
     func testInitDyadNodeCount() {
-        let speller = PitchSpeller(pitches: [60,61], parsimonyPivot: 2)
+        let speller = PitchSpeller(pitches: [60,61], parsimonyPivot: Pitch.Spelling(.d))
         XCTAssertEqual(speller.flowNetwork.internalNodes.count, 4)
     }
 
     func testInitTriadEdges() {
 
-        let speller = PitchSpeller(pitches: [60,61,66], parsimonyPivot: 2)
+        let speller = PitchSpeller(pitches: [60,61,66], parsimonyPivot: Pitch.Spelling(.d))
         let flowNetwork = speller.flowNetwork
 
         for internalNode in speller.flowNetwork.internalNodes {
@@ -50,7 +50,7 @@ class WetherfieldTests: XCTestCase {
     }
 
     func testEdgeUpdating() {
-        let speller = PitchSpeller(pitches: [60,61,66], parsimonyPivot: 2)
+        let speller = PitchSpeller(pitches: [60,61,66], parsimonyPivot: Pitch.Spelling(.d))
         let flowNetwork = speller.flowNetwork
         flowNetwork.internalNodes.forEach { print($0) }
     }


### PR DESCRIPTION
- Make `parsimonyPivot` a `Pitch.Spelling` instead of a `Pitch.Class`.
- Implement `UnassignedNode` and `AssignedNode`