### PR TITLE
[PitchSpeller / WIP] Graph with flags

### DIFF
--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -11,3 +11,7 @@ protocol Undirected: Directedness { }
 
 enum WithDirectedEdges: Directed { }
 enum WithUndirectedEdges: Undirected { }
+
+struct _Graph<DirectednessFlag: Directedness> {
+    
+}

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -11,7 +11,9 @@ protocol Directedness { }
 protocol Directed: Directedness { }
 protocol Undirected: Directedness { }
 
-enum WithDirectedEdges: Directed { }
+typealias DirectedOver = OrderedPair
+extension DirectedOver: Directed { }
+
 enum WithUndirectedEdges: Undirected { }
 
 // MARK: - Weightedness Flags

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -18,6 +18,7 @@ enum WithUndirectedEdges: Undirected { }
 
 protocol Weightedness { }
 protocol Unweighted: Weightedness { }
+extension Double: Weightedness { }
 
 enum WithoutWeights: Unweighted { }
 

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -25,7 +25,9 @@ protocol AsWeight: Weightedness { }
 
 // Allows Double to be used as an edge weight
 extension Double: AsWeight { }
-enum WithoutWeights: Unweighted { }
+enum WithoutWeights: Unweighted {
+    case unweighted
+}
 
 struct _Graph<Weight: Weightedness, Pair: SymmetricPair & Directedness> {
     

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -1,0 +1,7 @@
+//
+//  _Graph.swift
+//  PitchSpeller
+//
+//  Created by Benjamin Wetherfield on 7/14/18.
+//
+

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -38,6 +38,7 @@ struct _Graph<Weight: Weightedness, Pair: SymmetricPair & Directedness> {
         // MARK: - Instance Properties
         
         let nodes: Pair
+        let weight: Weight
     }
 }
 

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -20,8 +20,7 @@ protocol Weightedness { }
 protocol Unweighted: Weightedness { }
 protocol AsWeight: Weightedness { }
 
-extension Double: Weightedness { }
-
+extension Double: AsWeight { }
 enum WithoutWeights: Unweighted { }
 
 struct _Graph<DirectednessFlag: Directedness> {

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -5,6 +5,8 @@
 //  Created by Benjamin Wetherfield on 7/14/18.
 //
 
+// MARK: - Directedness Flags
+
 protocol Directedness { }
 protocol Directed: Directedness { }
 protocol Undirected: Directedness { }

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -39,6 +39,13 @@ struct _Graph<Weight: Weightedness, Pair: SymmetricPair & Directedness> {
         
         let nodes: Pair
         let weight: Weight
+        
+        // MARK: - Initializers
+        
+        init (_ a: _Graph.Node, _ b: _Graph.Node, withWeight weight: Weight) {
+            self.nodes = Pair(a, b)
+            self.weight = weight
+        }
     }
 }
 

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -29,7 +29,7 @@ enum WithoutWeights: Unweighted { }
 
 struct _Graph<Weight: Weightedness, Pair: SymmetricPair & Directedness> {
     
-    
+    typealias Node = Pair.A
 }
 
 extension _Graph where Weight: Numeric, Pair: Directed {

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -42,6 +42,14 @@ struct _Graph<Weight: Weightedness, Pair: SymmetricPair & Directedness> {
     }
 }
 
+extension _Graph.Edge where Weight == WithoutWeights {
+    
+    init (_ a: _Graph.Node, _ b: _Graph.Node) {
+        self.nodes = Pair(a, b)
+        self.weight = .unweighted
+    }
+}
+
 extension _Graph.Edge where Pair: Directed {
     
     // MARK: - Instance Properties

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -27,6 +27,6 @@ struct _Graph<WeightednessFlag: Weightedness, DirectednessFlag: Directedness> {
     
 }
 
-extension _Graph where DirectednessFlag: Directed {
+extension _Graph where WeightednessFlag: Numeric, DirectednessFlag: Directed {
     
 }

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -30,6 +30,13 @@ enum WithoutWeights: Unweighted { }
 struct _Graph<Weight: Weightedness, Pair: SymmetricPair & Directedness> {
     
     typealias Node = Pair.A
+    
+    struct Edge {
+        
+        // MARK: - Instance Properties
+        
+        let nodes: Pair
+    }
 }
 
 extension _Graph where Weight: Numeric, Pair: Directed {

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -20,6 +20,7 @@ protocol Weightedness { }
 protocol Unweighted: Weightedness { }
 protocol AsWeight: Weightedness { }
 
+// Allows Double to be used as an edge weight
 extension Double: AsWeight { }
 enum WithoutWeights: Unweighted { }
 

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -18,6 +18,8 @@ enum WithUndirectedEdges: Undirected { }
 
 protocol Weightedness { }
 protocol Unweighted: Weightedness { }
+protocol AsWeight: Weightedness { }
+
 extension Double: Weightedness { }
 
 enum WithoutWeights: Unweighted { }

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -27,7 +27,7 @@ protocol AsWeight: Weightedness { }
 extension Double: AsWeight { }
 enum WithoutWeights: Unweighted { }
 
-struct _Graph<Weight: Weightedness, Pair: Directedness> {
+struct _Graph<Weight: Weightedness, Pair: SymmetricPair & Directedness> {
     
     
 }

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -27,10 +27,11 @@ protocol AsWeight: Weightedness { }
 extension Double: AsWeight { }
 enum WithoutWeights: Unweighted { }
 
-struct _Graph<Weight: Weightedness, DirectednessFlag: Directedness> {
+struct _Graph<Weight: Weightedness, Pair: Directedness> {
+    
     
 }
 
-extension _Graph where Weight: Numeric, DirectednessFlag: Directed {
+extension _Graph where Weight: Numeric, Pair: Directed {
     
 }

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -14,6 +14,13 @@ protocol Undirected: Directedness { }
 enum WithDirectedEdges: Directed { }
 enum WithUndirectedEdges: Undirected { }
 
+// MARK: - Weightedness Flags
+
+protocol Weightedness { }
+protocol Unweighted: Weightedness { }
+
+enum WithoutWeights: Unweighted { }
+
 struct _Graph<DirectednessFlag: Directedness> {
     
 }

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -23,7 +23,7 @@ protocol AsWeight: Weightedness { }
 extension Double: AsWeight { }
 enum WithoutWeights: Unweighted { }
 
-struct _Graph<DirectednessFlag: Directedness> {
+struct _Graph<WeightednessFlag: Weightedness, DirectednessFlag: Directedness> {
     
 }
 

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -15,3 +15,7 @@ enum WithUndirectedEdges: Undirected { }
 struct _Graph<DirectednessFlag: Directedness> {
     
 }
+
+extension _Graph where DirectednessFlag: Directed {
+    
+}

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -51,6 +51,8 @@ struct _Graph<Weight: Weightedness, Pair: SymmetricPair & Directedness> {
 
 extension _Graph.Edge where Weight == WithoutWeights {
     
+    // MARK: - Initializers
+    
     init (_ a: _Graph.Node, _ b: _Graph.Node) {
         self.nodes = Pair(a, b)
         self.weight = .unweighted

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -5,3 +5,9 @@
 //  Created by Benjamin Wetherfield on 7/14/18.
 //
 
+protocol Directedness { }
+protocol Directed: Directedness { }
+protocol Undirected: Directedness { }
+
+enum WithDirectedEdges: Directed { }
+enum WithUndirectedEdges: Undirected { }

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -39,6 +39,14 @@ struct _Graph<Weight: Weightedness, Pair: SymmetricPair & Directedness> {
     }
 }
 
+extension _Graph.Edge where Pair: Directed {
+    
+    // MARK: - Instance Properties
+    
+    var source: _Graph.Node { return nodes.a }
+    var destination: _Graph.Node { return nodes.b }
+}
+
 extension _Graph where Weight: Numeric, Pair: Directed {
     
 }

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -14,7 +14,8 @@ protocol Undirected: Directedness { }
 typealias DirectedOver = OrderedPair
 extension DirectedOver: Directed { }
 
-enum WithUndirectedEdges: Undirected { }
+typealias UndirectedOver = UnorderedPair
+extension UndirectedOver: Undirected { }
 
 // MARK: - Weightedness Flags
 

--- a/Sources/PitchSpeller/Data Structures/_Graph.swift
+++ b/Sources/PitchSpeller/Data Structures/_Graph.swift
@@ -23,10 +23,10 @@ protocol AsWeight: Weightedness { }
 extension Double: AsWeight { }
 enum WithoutWeights: Unweighted { }
 
-struct _Graph<WeightednessFlag: Weightedness, DirectednessFlag: Directedness> {
+struct _Graph<Weight: Weightedness, DirectednessFlag: Directedness> {
     
 }
 
-extension _Graph where WeightednessFlag: Numeric, DirectednessFlag: Directed {
+extension _Graph where Weight: Numeric, DirectednessFlag: Directed {
     
 }


### PR DESCRIPTION
Allows Directedness and Weight flags to be passed into a Graph when declared.

Directedness flag also passes in the Pair type used to represent Edges in the graph as well as the node.

TODO: integrate with existing Graph code.