### PR TITLE
Use built-in InvertibleEnum.inverse implementation in NamedOrderedInterval

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/dn-m/Music",
         "state": {
           "branch": null,
-          "revision": "4a7367927050bcef6cb0595c99d1efc5c678286d",
-          "version": "0.1.0"
+          "revision": "78dd907a0f2d6cab643ed4c7e6ee2a8bfcc1bcf6",
+          "version": "0.1.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/dn-m/Structure",
         "state": {
           "branch": null,
-          "revision": "dc5dbd53af383dd651a2539802b34b01279fd249",
-          "version": "0.4.0"
+          "revision": "16221b5068b7c3e52066929cb0a943d3ccc3f149",
+          "version": "0.6.0"
         }
       }
     ]

--- a/Sources/SpelledPitch/NamedOrderedInterval.swift
+++ b/Sources/SpelledPitch/NamedOrderedInterval.swift
@@ -28,18 +28,7 @@ public struct NamedOrderedInterval {
 
         /// Perfect `Ordinal` cases.
         public enum Perfect: InvertibleEnum {
-            case unison, fourth, fifth
-
-            /// Customizes the `InvertibleEnum` `inverse` implementation to return `unison` as the
-            /// inverse of `unison`.
-            ///
-            /// - Returns: Inverse of `self`.
-            public var inverse: Perfect {
-                let index = Perfect.allCases.index(of: self)!
-                guard index > 0 else { return self }
-                let inverseIndex = Perfect.allCases.count - index
-                return Perfect.allCases[inverseIndex]
-            }
+            case fourth, unison, fifth
         }
 
         /// Imperfect `Ordinal` cases


### PR DESCRIPTION
This PR reorders the cases in `NamedOrderedInterval.Perfect` so as to use the built-in implementation of `inverse` in the `InvertibleEnum` protocol.