### PR TITLE
Flow tests

### DIFF
--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/FlowNetwork.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/FlowNetwork.swift
@@ -27,6 +27,8 @@ extension FlowNetwork {
     /// Create a `FlowNetwork` with the given `directedGraph` and the given `source` and `sink` nodes.
     init(_ directedGraph: WeightedDirectedGraph<Node,Weight>, source: Node, sink: Node) {
         self.directedGraph = directedGraph
+        self.directedGraph.insert(source)
+        self.directedGraph.insert(sink)
         self.source = source
         self.sink = sink
     }

--- a/Tests/SpelledPitchTests/FlowNetworkTests.swift
+++ b/Tests/SpelledPitchTests/FlowNetworkTests.swift
@@ -56,8 +56,8 @@ class FlowNetworkTests: XCTestCase {
     }
 
     func testMinimumCut() {
-        XCTAssertEqual(simpleFlowNetwork.minimumCut.0, Set(["s"]))
-        XCTAssertEqual(simpleFlowNetwork.minimumCut.1, Set(["a","b","t"]))
+        XCTAssertEqual(simpleFlowNetwork.minimumCut.0, ["s"])
+        XCTAssertEqual(simpleFlowNetwork.minimumCut.1, ["a","b","t"])
     }
     
     func testUnreachableMinimumCut() {

--- a/Tests/SpelledPitchTests/FlowNetworkTests.swift
+++ b/Tests/SpelledPitchTests/FlowNetworkTests.swift
@@ -72,6 +72,14 @@ class FlowNetworkTests: XCTestCase {
         let cut = FlowNetwork(graph, source: "s", sink: "t").minimumCut
         XCTAssertEqual(cut.0.union(cut.1), ["s", "a", "t", "b"])
     }
+    
+    func testFlowNetworkAbsorbsSourceSink() {
+        var graph = WeightedDirectedGraph<String,Double>()
+        graph.insert("a")
+        let flowNetwork = FlowNetwork(graph, source: "s", sink: "t")
+        XCTAssert(flowNetwork.directedGraph.contains("s"))
+        XCTAssert(flowNetwork.directedGraph.contains("t"))
+    }
 
     func testRandomNetwork() {
         let iterations = 1

--- a/Tests/SpelledPitchTests/FlowNetworkTests.swift
+++ b/Tests/SpelledPitchTests/FlowNetworkTests.swift
@@ -59,6 +59,19 @@ class FlowNetworkTests: XCTestCase {
         XCTAssertEqual(simpleFlowNetwork.minimumCut.0, Set(["s"]))
         XCTAssertEqual(simpleFlowNetwork.minimumCut.1, Set(["a","b","t"]))
     }
+    
+    func testUnreachableMinimumCut() {
+        var graph = WeightedDirectedGraph<String,Int>()
+        graph.insert("s")
+        graph.insert("a")
+        graph.insert("b")
+        graph.insert("t")
+        graph.insertEdge(from: "s", to: "a", weight: 2)
+        graph.insertEdge(from: "a", to: "b", weight: 2)
+        graph.insertEdge(from: "b", to: "t", weight: 3)
+        let cut = FlowNetwork(graph, source: "s", sink: "t").minimumCut
+        XCTAssertEqual(cut.0.union(cut.1), ["s", "a", "t", "b"])
+    }
 
     func testRandomNetwork() {
         let iterations = 1

--- a/Tests/SpelledPitchTests/FlowNetworkTests.swift
+++ b/Tests/SpelledPitchTests/FlowNetworkTests.swift
@@ -57,6 +57,7 @@ class FlowNetworkTests: XCTestCase {
 
     func testMinimumCut() {
         XCTAssertEqual(simpleFlowNetwork.minimumCut.0, Set(["s"]))
+        XCTAssertEqual(simpleFlowNetwork.minimumCut.1, Set(["a","b","t"]))
     }
 
     func testRandomNetwork() {


### PR DESCRIPTION
PR to add more tests to `FlowNetwork`!

For now the issue of `source` and `sink` being in `FlowNetwork` has been put in a test that will ultimately be made to fail and rewritten.