### PR TITLE
Clean up / Refactor

### DIFF
--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/DirectedGraphProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/DirectedGraphProtocol.swift
@@ -16,4 +16,8 @@ struct DirectedGraphScheme <Node>: DirectedGraphSchemeProtocol, UnweightedGraphS
     init (_ contains: @escaping (Edge) -> Bool) {
         self.contains = contains
     }
+    
+    func contains(from start: Node, to end: Node) -> Bool {
+        return contains(Edge(start, end))
+    }
 }

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/FlowNetwork.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/FlowNetwork.swift
@@ -51,7 +51,7 @@ extension FlowNetwork {
             }
         }
     }
-    
+
     mutating func mask <G: GraphProtocol> (_ adjacencyCarrying: AdjacencyCarrying<G>)
         where Node == G.Node
     {
@@ -60,9 +60,21 @@ extension FlowNetwork {
         }
     }
     
-    mutating func mask (_ adjacencyScheme: GraphScheme<Node>) {
-        for edge in edges where !adjacencyScheme.contains(GraphScheme<Node>.Edge(edge.a, edge.b)) {
+    mutating func mask <Scheme: UnweightedGraphSchemeProtocol> (_ adjacencyScheme: Scheme) where
+        Scheme.Node == Node
+    {
+        for edge in edges where !adjacencyScheme.contains(from: edge.a, to: edge.b) {
             remove(edge)
+        }
+    }
+    
+    mutating func mask <Scheme: WeightedGraphSchemeProtocol> (_ weightScheme: Scheme) where
+        Scheme.Node == Node,
+        Scheme.Weight == Weight
+    {
+        for edge in edges {
+            guard let scalar = weightScheme.weight(from: edge.a, to: edge.b) else { remove(edge); return }
+            updateEdge(edge) { $0 * scalar }
         }
     }
 }

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/GraphScheme.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/GraphScheme.swift
@@ -16,4 +16,8 @@ struct GraphScheme <Node>: UndirectedGraphSchemeProtocol, UnweightedGraphSchemeP
     init (_ contains: @escaping (Edge) -> Bool) {
         self.contains = contains
     }
+    
+    func contains(from start: Node, to end: Node) -> Bool {
+        return contains(Edge(start, end))
+    }
 }

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/GraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/GraphSchemeProtocol.swift
@@ -18,6 +18,6 @@ extension GraphProtocol {
         G.Edge == Edge,
         G.Node == Node
     {
-        return G.init(self.contains)
+        return G(self.contains)
     }
 }

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/UnweightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/UnweightedGraphSchemeProtocol.swift
@@ -11,6 +11,8 @@ public protocol UnweightedGraphSchemeProtocol: GraphSchemeProtocol {
     var contains: (Edge) -> Bool { get }
     
     init (_ contains: @escaping (Edge) -> Bool)
+    
+    func contains (from start: Node, to end: Node) -> Bool
 }
 
 extension UnweightedGraphSchemeProtocol {

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/UnweightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/UnweightedGraphSchemeProtocol.swift
@@ -32,3 +32,13 @@ extension UnweightedGraphSchemeProtocol where Self: UndirectedGraphSchemeProtoco
         return Self.init { edge in lhs.contains(edge) || rhs.contains(edge) }
     }
 }
+
+extension UnweightedGraphSchemeProtocol where Self: DirectedGraphSchemeProtocol {
+    
+    static func * <Scheme> (lhs: Self, rhs: Scheme) -> Self where
+        Scheme: UnweightedGraphSchemeProtocol,
+        Scheme.Node == Node
+    {
+        return Self.init { edge in lhs.contains(edge) && rhs.contains(from: edge.a, to: edge.b) }
+    }
+}

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/UnweightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/UnweightedGraphSchemeProtocol.swift
@@ -42,3 +42,17 @@ extension UnweightedGraphSchemeProtocol where Self: DirectedGraphSchemeProtocol 
         return Self.init { edge in lhs.contains(edge) && rhs.contains(from: edge.a, to: edge.b) }
     }
 }
+
+extension UnweightedGraphSchemeProtocol {
+    
+    static func * <Weight, Scheme> (lhs: Weight, rhs: Self) -> Scheme where
+        Scheme: WeightedGraphSchemeProtocol,
+        Scheme.Weight == Weight,
+        Scheme.Node == Node,
+        Scheme.Edge == Edge
+    {
+        return Scheme { edge in
+            return rhs.contains(edge) ? lhs : nil
+        }
+    }
+}

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/UnweightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/UnweightedGraphSchemeProtocol.swift
@@ -18,18 +18,18 @@ public protocol UnweightedGraphSchemeProtocol: GraphSchemeProtocol {
 extension UnweightedGraphSchemeProtocol {
     @inlinable
     func pullback <H> (_ f: @escaping (H.Node) -> Node) -> H where H: UnweightedGraphSchemeProtocol {
-        return H.init { self.contains(Edge(f($0.a),f($0.b))) }
+        return H { self.contains(Edge(f($0.a),f($0.b))) }
     }
 }
 
 extension UnweightedGraphSchemeProtocol where Self: UndirectedGraphSchemeProtocol {
     
     static func * (lhs: Self, rhs: Self) -> Self {
-        return Self.init { edge in lhs.contains(edge) && rhs.contains(edge) }
+        return Self { edge in lhs.contains(edge) && rhs.contains(edge) }
     }
     
     static func + (lhs: Self, rhs: Self) -> Self {
-        return Self.init { edge in lhs.contains(edge) || rhs.contains(edge) }
+        return Self { edge in lhs.contains(edge) || rhs.contains(edge) }
     }
 }
 
@@ -39,7 +39,7 @@ extension UnweightedGraphSchemeProtocol where Self: DirectedGraphSchemeProtocol 
         Scheme: UnweightedGraphSchemeProtocol,
         Scheme.Node == Node
     {
-        return Self.init { edge in lhs.contains(edge) && rhs.contains(from: edge.a, to: edge.b) }
+        return Self { edge in lhs.contains(edge) && rhs.contains(from: edge.a, to: edge.b) }
     }
 }
 

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightCarrying.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightCarrying.swift
@@ -80,7 +80,7 @@ extension WeightCarrying {
         Scheme.Node == G.Node,
         Scheme.Weight == G.Weight
     {
-        return Scheme.init(weight)
+        return Scheme(weight)
     }
 }
 

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedDirectedGraphSchema.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedDirectedGraphSchema.swift
@@ -16,4 +16,8 @@ struct WeightedDirectedGraphScheme <Node,Weight>: DirectedGraphSchemeProtocol, W
     init (_ weight: @escaping (Edge) -> Weight?) {
         self.weight = weight
     }
+    
+    func weight(from start: Node, to end: Node) -> Weight? {
+        return weight(Edge(start, end))
+    }
 }

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedDirectedGraphScheme.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedDirectedGraphScheme.swift
@@ -1,5 +1,5 @@
 //
-//  WeightedDirectedGraphSchema.swift
+//  WeightedDirectedGraphScheme.swift
 //  SpelledPitch
 //
 //  Created by Benjamin Wetherfield on 03/11/2018.

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphScheme.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphScheme.swift
@@ -16,4 +16,8 @@ struct WeightedGraphScheme <Node,Weight>: UndirectedGraphSchemeProtocol, Weighte
     init (_ weight: @escaping (Edge) -> Weight?) {
         self.weight = weight
     }
+    
+    func weight(from start: Node, to end: Node) -> Weight? {
+        return weight(Edge(start, end))
+    }
 }

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
@@ -23,7 +23,7 @@ extension WeightedGraphSchemeProtocol {
         H: WeightedGraphSchemeProtocol,
         H.Weight == Weight
     {
-        return H.init { self.weight(Edge(f($0.a),f($0.b))) }
+        return H.init { self.weight(from: f($0.a), to: f($0.b)) }
     }
 
     @inlinable

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
@@ -34,12 +34,3 @@ extension WeightedGraphSchemeProtocol {
         return H.init { self.weight($0) != nil }
     }
 }
-
-extension WeightedGraphProtocol {
-    func weightScheme <G> (_ f: @escaping (G.Node) -> Node) -> WeightCarrying<G> where
-        G: WeightedGraphProtocol,
-        G.Weight == Weight
-    {
-        return WeightCarrying.build(from: self).pullback(f)
-    }
-}

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
@@ -23,9 +23,7 @@ extension WeightedGraphSchemeProtocol {
     {
         return H.init { self.weight(Edge(f($0.a),f($0.b))) }
     }
-}
 
-extension WeightedGraphSchemeProtocol {
     @inlinable
     func unweighted <H> () -> H where
         H: UnweightedGraphSchemeProtocol,

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
@@ -23,7 +23,7 @@ extension WeightedGraphSchemeProtocol {
         H: WeightedGraphSchemeProtocol,
         H.Weight == Weight
     {
-        return H.init { self.weight(from: f($0.a), to: f($0.b)) }
+        return H { self.weight(from: f($0.a), to: f($0.b)) }
     }
 
     @inlinable
@@ -31,7 +31,7 @@ extension WeightedGraphSchemeProtocol {
         H: UnweightedGraphSchemeProtocol,
         H.Edge == Edge
     {
-        return H.init { self.weight($0) != nil }
+        return H { self.weight($0) != nil }
     }
 }
 

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
@@ -59,4 +59,24 @@ extension WeightedGraphSchemeProtocol where Self: DirectedGraphSchemeProtocol, W
             return lweight * rweight
         }
     }
+    
+    static func * <Scheme> (lhs: Self, rhs: Scheme) -> Self where
+        Scheme: UnweightedGraphSchemeProtocol,
+        Scheme.Node == Node
+    {
+        return Self { edge in
+            if let lweight = lhs.weight(edge) {
+                return rhs.contains(from: edge.a, to: edge.b) ? lweight : nil
+            } else {
+                return nil
+            }
+        }
+    }
+    
+    static func * <Scheme> (lhs: Scheme, rhs: Self) -> Self where
+        Scheme: UnweightedGraphSchemeProtocol,
+        Scheme.Node == Node
+    {
+        return rhs * lhs
+    }
 }

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
@@ -13,6 +13,8 @@ public protocol WeightedGraphSchemeProtocol: GraphSchemeProtocol {
     var weight: (Edge) -> Weight? { get }
     
     init (_ weight: @escaping (Edge) -> Weight?)
+    
+    func weight (from start: Node, to end: Node) -> Weight?
 }
 
 extension WeightedGraphSchemeProtocol {

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
@@ -34,3 +34,29 @@ extension WeightedGraphSchemeProtocol {
         return H.init { self.weight($0) != nil }
     }
 }
+
+extension WeightedGraphSchemeProtocol where Self: UndirectedGraphSchemeProtocol, Weight: Numeric {
+    
+    static func * (lhs: Self, rhs: Self) -> Self {
+        return Self { edge in
+            guard let lweight = lhs.weight(edge), let rweight = rhs.weight(edge) else { return nil }
+            return lweight * rweight
+        }
+    }
+}
+
+extension WeightedGraphSchemeProtocol where Self: DirectedGraphSchemeProtocol, Weight: Numeric {
+    
+    static func * <Scheme> (lhs: Self, rhs: Scheme) -> Self where
+    Scheme: WeightedGraphSchemeProtocol,
+    Scheme.Node == Node,
+    Scheme.Weight == Weight
+    {
+        return Self { edge in
+            guard
+                let lweight = lhs.weight(edge),
+                let rweight = rhs.weight(from: edge.a, to: edge.b) else { return nil }
+            return lweight * rweight
+        }
+    }
+}


### PR DESCRIPTION
Cleans up / refactors code. Generalizes scheme multiplications and masks to the protocol level using `weight(from:to:)` and `contains(from:to:)` syntax.