### PR TITLE
Add directed() analog to unweighted() for undirected schemes

### DIFF
--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/UndirectedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/UndirectedGraphSchemeProtocol.swift
@@ -8,3 +8,24 @@
 import DataStructures
 
 public protocol UndirectedGraphSchemeProtocol: GraphSchemeProtocol where Edge == UnorderedPair<Node> { }
+
+extension UndirectedGraphSchemeProtocol where Self: WeightedGraphSchemeProtocol {
+    
+    func directed <D> () -> D where
+        D: DirectedGraphSchemeProtocol & WeightedGraphSchemeProtocol,
+        D.Weight == Weight,
+        D.Node == Node
+    {
+        return .init { edge in self.weight(from: edge.a, to: edge.b) }
+    }
+}
+
+extension UndirectedGraphSchemeProtocol where Self: UnweightedGraphSchemeProtocol {
+    
+    func directed <D> () -> D where
+        D: DirectedGraphSchemeProtocol & UnweightedGraphSchemeProtocol,
+        D.Node == Node
+    {
+        return .init { edge in self.contains(from: edge.a, to: edge.b) }
+    }
+}

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/UnweightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/UnweightedGraphSchemeProtocol.swift
@@ -56,3 +56,13 @@ extension UnweightedGraphSchemeProtocol {
         }
     }
 }
+
+extension UnweightedGraphSchemeProtocol where Self: UndirectedGraphSchemeProtocol {
+    
+    func directed <D> () -> D where
+        D: DirectedGraphSchemeProtocol & UnweightedGraphSchemeProtocol,
+        D.Node == Node
+    {
+        return .init { edge in self.contains(from: edge.a, to: edge.b) }
+    }
+}

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/UnweightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/UnweightedGraphSchemeProtocol.swift
@@ -57,12 +57,3 @@ extension UnweightedGraphSchemeProtocol {
     }
 }
 
-extension UnweightedGraphSchemeProtocol where Self: UndirectedGraphSchemeProtocol {
-    
-    func directed <D> () -> D where
-        D: DirectedGraphSchemeProtocol & UnweightedGraphSchemeProtocol,
-        D.Node == Node
-    {
-        return .init { edge in self.contains(from: edge.a, to: edge.b) }
-    }
-}

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
@@ -80,14 +80,3 @@ extension WeightedGraphSchemeProtocol where Self: DirectedGraphSchemeProtocol, W
         return rhs * lhs
     }
 }
-
-extension WeightedGraphSchemeProtocol where Self: UndirectedGraphSchemeProtocol {
-    
-    func directed <D> () -> D where
-        D: DirectedGraphSchemeProtocol & WeightedGraphSchemeProtocol,
-        D.Weight == Weight,
-        D.Node == Node
-    {
-        return .init { edge in self.weight(from: edge.a, to: edge.b) }
-    }
-}

--- a/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
+++ b/Sources/SpelledPitch/PitchSpeller/Wetherfield/WeightedGraphSchemeProtocol.swift
@@ -80,3 +80,14 @@ extension WeightedGraphSchemeProtocol where Self: DirectedGraphSchemeProtocol, W
         return rhs * lhs
     }
 }
+
+extension WeightedGraphSchemeProtocol where Self: UndirectedGraphSchemeProtocol {
+    
+    func directed <D> () -> D where
+        D: DirectedGraphSchemeProtocol & WeightedGraphSchemeProtocol,
+        D.Weight == Weight,
+        D.Node == Node
+    {
+        return .init { edge in self.weight(from: edge.a, to: edge.b) }
+    }
+}


### PR DESCRIPTION
Schemes allow us to inexpensively convert from an undirected type to a directed one. 

Now `{ edge in self.contains(from: edge.a, to: edge.b) }(someEdge) == true` [see constructor] if and only if `UnorderedPair(SomeEdge.a, SomeEdge.b)` (` == UnorderedPair(SomeEdge.b, SomeEdge.a)`) is "contained" in the  undirected scheme.

Similarly for `weight`...